### PR TITLE
feat: Add Confirmation Modal To Mark Account Notifications As Read

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,10 +1,8 @@
 name: Triage PR
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize, ready_for_review]
-    branches: [main]
-
+  pull_request_target:
+  
 permissions:
   contents: read # the config file
   pull-requests: write # for labeling pull requests (on: pull_request_target or on: pull_request)

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -17,3 +17,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: fuxingloh/multi-labeler@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -17,5 +17,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: fuxingloh/multi-labeler@v4
-        with:
-          github-token: ${{secrets.GH_TOKEN_LABELER}} 

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -18,4 +18,4 @@ jobs:
     steps:
       - uses: fuxingloh/multi-labeler@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,9 +1,6 @@
 name: Triage PR
 
 on:
-  pull_request_target:
-  # for OSS with public contributions (forked PR)
-
   pull_request:
     types: [opened, edited, synchronize, ready_for_review]
     branches: [main]
@@ -20,3 +17,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: fuxingloh/multi-labeler@v4
+        with:
+          github-token: ${{secrets.GH_TOKEN_LABELER}} 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     needs: run-unit-tests
+    if: false  # Disable this step
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     needs: run-unit-tests
-    if: false  # Disable this step
+    if: github.event.pull_request.head.repo.fork == false  # Only analyze PRs from the same repository. Limitation of SonarCloud
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/components/notifications/AccountNotifications.test.tsx
+++ b/src/components/notifications/AccountNotifications.test.tsx
@@ -148,7 +148,7 @@ describe('components/notifications/AccountNotifications.tsx', () => {
     expect(openMyPullRequestsMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should mark all account notifications as read', async () => {
+  it('should mark all account notifications as read when `confirmed`', async () => {
     const props = {
       account: mockAtlassianCloudAccount,
       notifications: mockAtlassifyNotifications,
@@ -171,8 +171,37 @@ describe('components/notifications/AccountNotifications.tsx', () => {
     });
 
     fireEvent.click(screen.getByTestId('account-mark-as-read'));
+    fireEvent.click(screen.getByTestId('account-mark-as-read-confirm'));
 
     expect(markNotificationsReadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip marking all account notifications as read when `cancelled`', async () => {
+    const props = {
+      account: mockAtlassianCloudAccount,
+      notifications: mockAtlassifyNotifications,
+      error: null,
+    };
+
+    const markNotificationsReadMock = jest.fn();
+
+    await act(async () => {
+      render(
+        <AppContext.Provider
+          value={{
+            settings: mockSettings,
+            markNotificationsRead: markNotificationsReadMock,
+          }}
+        >
+          <AccountNotifications {...props} />
+        </AppContext.Provider>,
+      );
+    });
+
+    fireEvent.click(screen.getByTestId('account-mark-as-read'));
+    fireEvent.click(screen.getByTestId('account-mark-as-read-cancel'));
+
+    expect(markNotificationsReadMock).not.toHaveBeenCalled();
   });
 
   it('should toggle account notifications visibility', async () => {

--- a/src/components/notifications/AccountNotifications.tsx
+++ b/src/components/notifications/AccountNotifications.tsx
@@ -178,7 +178,11 @@ export const AccountNotifications: FC<IAccountNotifications> = (
                 shape="circle"
                 spacing="compact"
                 appearance="subtle"
-                onClick={openModal}
+                onClick={(event: MouseEvent<HTMLElement>) => {
+                  // Don't trigger onClick of parent element.
+                  event.stopPropagation();
+                  openModal();
+                }}
                 testId="account-mark-as-read"
               />
             </Tooltip>
@@ -210,21 +214,27 @@ export const AccountNotifications: FC<IAccountNotifications> = (
                   </ModalHeader>
                   <ModalBody>
                     <p>
-                      Please confirm that you want to
-                      mark <strong>all account notifications</strong> as read
+                      Please confirm that you want to mark{' '}
+                      <strong>all account notifications</strong> as read
                     </p>
                   </ModalBody>
                   <ModalFooter>
                     <Button
                       appearance="subtle"
-                      onClick={() => closeModal()}
+                      onClick={(event: MouseEvent<HTMLElement>) => {
+                        // Don't trigger onClick of parent element.
+                        event.stopPropagation();
+                        closeModal();
+                      }}
                       testId="account-mark-as-read-cancel"
                     >
                       Cancel
                     </Button>
                     <Button
                       appearance="warning"
-                      onClick={() => {
+                      onClick={(event: MouseEvent<HTMLElement>) => {
+                        // Don't trigger onClick of parent element.
+                        event.stopPropagation();
                         markNotificationsRead(notifications);
                         closeModal();
                       }}

--- a/src/components/notifications/AccountNotifications.tsx
+++ b/src/components/notifications/AccountNotifications.tsx
@@ -179,74 +179,12 @@ export const AccountNotifications: FC<IAccountNotifications> = (
                 spacing="compact"
                 appearance="subtle"
                 onClick={(event: MouseEvent<HTMLElement>) => {
-                  // Don't trigger onClick of parent element.
                   event.stopPropagation();
                   openModal();
                 }}
                 testId="account-mark-as-read"
               />
             </Tooltip>
-
-            <ModalTransition>
-              {isOpen && (
-                <Modal onClose={closeModal}>
-                  <ModalHeader>
-                    <Grid
-                      gap="space.200"
-                      templateAreas={['title close']}
-                      xcss={gridStyles}
-                    >
-                      <Flex xcss={closeContainerStyles} justifyContent="end">
-                        <IconButton
-                          appearance="subtle"
-                          icon={CrossIcon}
-                          label="Close"
-                          onClick={() => closeModal()}
-                          testId="account-mark-as-read-close"
-                        />
-                      </Flex>
-                      <Flex xcss={titleContainerStyles} justifyContent="start">
-                        <ModalTitle appearance="warning">
-                          Are you sure?
-                        </ModalTitle>
-                      </Flex>
-                    </Grid>
-                  </ModalHeader>
-                  <ModalBody>
-                    <p>
-                      Please confirm that you want to mark{' '}
-                      <strong>all account notifications</strong> as read
-                    </p>
-                  </ModalBody>
-                  <ModalFooter>
-                    <Button
-                      appearance="subtle"
-                      onClick={(event: MouseEvent<HTMLElement>) => {
-                        // Don't trigger onClick of parent element.
-                        event.stopPropagation();
-                        closeModal();
-                      }}
-                      testId="account-mark-as-read-cancel"
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      appearance="warning"
-                      onClick={(event: MouseEvent<HTMLElement>) => {
-                        // Don't trigger onClick of parent element.
-                        event.stopPropagation();
-                        markNotificationsRead(notifications);
-                        closeModal();
-                      }}
-                      testId="account-mark-as-read-confirm"
-                    >
-                      Proceed
-                    </Button>
-                  </ModalFooter>
-                </Modal>
-              )}
-            </ModalTransition>
-
             <Tooltip
               content={toggleAccountNotificationsLabel}
               position="bottom"
@@ -287,6 +225,70 @@ export const AccountNotifications: FC<IAccountNotifications> = (
               ))}
         </Fragment>
       )}
+
+      <ModalTransition>
+        {isOpen && (
+          <Modal
+            onClose={(event: MouseEvent<HTMLElement>) => {
+              event.stopPropagation();
+              closeModal();
+            }}
+          >
+            <ModalHeader>
+              <Grid
+                gap="space.200"
+                templateAreas={['title close']}
+                xcss={gridStyles}
+              >
+                <Flex xcss={closeContainerStyles} justifyContent="end">
+                  <IconButton
+                    appearance="subtle"
+                    icon={CrossIcon}
+                    label="Close"
+                    onClick={(event: MouseEvent<HTMLElement>) => {
+                      event.stopPropagation();
+                      closeModal();
+                    }}
+                    testId="account-mark-as-read-close"
+                  />
+                </Flex>
+                <Flex xcss={titleContainerStyles} justifyContent="start">
+                  <ModalTitle appearance="warning">Are you sure?</ModalTitle>
+                </Flex>
+              </Grid>
+            </ModalHeader>
+            <ModalBody>
+              <p>
+                Please confirm that you want to mark{' '}
+                <strong>all account notifications</strong> as read
+              </p>
+            </ModalBody>
+            <ModalFooter>
+              <Button
+                appearance="subtle"
+                onClick={(event: MouseEvent<HTMLElement>) => {
+                  event.stopPropagation();
+                  closeModal();
+                }}
+                testId="account-mark-as-read-cancel"
+              >
+                Cancel
+              </Button>
+              <Button
+                appearance="warning"
+                onClick={(event: MouseEvent<HTMLElement>) => {
+                  event.stopPropagation();
+                  markNotificationsRead(notifications);
+                  closeModal();
+                }}
+                testId="account-mark-as-read-confirm"
+              >
+                Proceed
+              </Button>
+            </ModalFooter>
+          </Modal>
+        )}
+      </ModalTransition>
     </Stack>
   );
 };

--- a/src/components/notifications/AccountNotifications.tsx
+++ b/src/components/notifications/AccountNotifications.tsx
@@ -129,7 +129,6 @@ export const AccountNotifications: FC<IAccountNotifications> = (
                 }
                 primaryText={account.name}
                 onClick={(event: MouseEvent<HTMLElement>) => {
-                  // Don't trigger onClick of parent element.
                   event.stopPropagation();
                   openAccountProfile(account);
                 }}
@@ -155,7 +154,6 @@ export const AccountNotifications: FC<IAccountNotifications> = (
                 spacing="compact"
                 appearance="subtle"
                 onClick={(event: MouseEvent<HTMLElement>) => {
-                  // Don't trigger onClick of parent element.
                   event.stopPropagation();
                   openMyPullRequests();
                 }}
@@ -228,12 +226,7 @@ export const AccountNotifications: FC<IAccountNotifications> = (
 
       <ModalTransition>
         {isOpen && (
-          <Modal
-            onClose={(event: MouseEvent<HTMLElement>) => {
-              event.stopPropagation();
-              closeModal();
-            }}
-          >
+          <Modal onClose={() => closeModal()}>
             <ModalHeader>
               <Grid
                 gap="space.200"
@@ -245,10 +238,7 @@ export const AccountNotifications: FC<IAccountNotifications> = (
                     appearance="subtle"
                     icon={CrossIcon}
                     label="Close"
-                    onClick={(event: MouseEvent<HTMLElement>) => {
-                      event.stopPropagation();
-                      closeModal();
-                    }}
+                    onClick={() => closeModal()}
                     testId="account-mark-as-read-close"
                   />
                 </Flex>
@@ -266,18 +256,14 @@ export const AccountNotifications: FC<IAccountNotifications> = (
             <ModalFooter>
               <Button
                 appearance="subtle"
-                onClick={(event: MouseEvent<HTMLElement>) => {
-                  event.stopPropagation();
-                  closeModal();
-                }}
+                onClick={() => closeModal()}
                 testId="account-mark-as-read-cancel"
               >
                 Cancel
               </Button>
               <Button
                 appearance="warning"
-                onClick={(event: MouseEvent<HTMLElement>) => {
-                  event.stopPropagation();
+                onClick={() => {
                   markNotificationsRead(notifications);
                   closeModal();
                 }}

--- a/src/components/notifications/__snapshots__/AccountNotifications.test.tsx.snap
+++ b/src/components/notifications/__snapshots__/AccountNotifications.test.tsx.snap
@@ -2778,6 +2778,10 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
 {
   "asFragment": [Function],
   "baseElement": <body>
+    <div
+      class="atlaskit-portal-container"
+      style="display: flex;"
+    />
     <div>
       <div
         class="css-1npayr"
@@ -2800,7 +2804,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   type="button"
                 >
                   <div
-                    aria-labelledby="82"
+                    aria-labelledby="134"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -2818,7 +2822,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="82"
+                      id="134"
                     >
                       Atlassify
                     </span>
@@ -2997,7 +3001,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   type="button"
                 >
                   <div
-                    aria-labelledby="102"
+                    aria-labelledby="154"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -3015,7 +3019,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="102"
+                      id="154"
                     >
                       Atlassify
                     </span>
@@ -3184,7 +3188,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 role="presentation"
               >
                 <div
-                  aria-labelledby="110"
+                  aria-labelledby="162"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3202,7 +3206,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="110"
+                    id="162"
                   >
                     atlassify-app
                   </span>
@@ -3262,7 +3266,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   class="css-1w1rt7h"
                 >
                   <div
-                    aria-labelledby="112"
+                    aria-labelledby="164"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -3280,7 +3284,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="112"
+                      id="164"
                     >
                       #103: chore(deps): update dependency eslint
                     </span>
@@ -3390,7 +3394,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 role="presentation"
               >
                 <div
-                  aria-labelledby="116"
+                  aria-labelledby="168"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3408,7 +3412,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="116"
+                    id="168"
                   >
                     atlassify-app
                   </span>
@@ -3468,7 +3472,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   class="css-1w1rt7h"
                 >
                   <div
-                    aria-labelledby="118"
+                    aria-labelledby="170"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -3486,7 +3490,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="118"
+                      id="170"
                     >
                       Atlassify Home
                     </span>
@@ -3607,7 +3611,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 type="button"
               >
                 <div
-                  aria-labelledby="102"
+                  aria-labelledby="154"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3625,7 +3629,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="102"
+                    id="154"
                   >
                     Atlassify
                   </span>
@@ -3794,7 +3798,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
               role="presentation"
             >
               <div
-                aria-labelledby="110"
+                aria-labelledby="162"
                 role="img"
                 style="display: inline-block; position: relative; outline: 0;"
               >
@@ -3812,7 +3816,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 </span>
                 <span
                   hidden=""
-                  id="110"
+                  id="162"
                 >
                   atlassify-app
                 </span>
@@ -3872,7 +3876,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 class="css-1w1rt7h"
               >
                 <div
-                  aria-labelledby="112"
+                  aria-labelledby="164"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3890,7 +3894,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="112"
+                    id="164"
                   >
                     #103: chore(deps): update dependency eslint
                   </span>
@@ -4000,7 +4004,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
               role="presentation"
             >
               <div
-                aria-labelledby="116"
+                aria-labelledby="168"
                 role="img"
                 style="display: inline-block; position: relative; outline: 0;"
               >
@@ -4018,7 +4022,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 </span>
                 <span
                   hidden=""
-                  id="116"
+                  id="168"
                 >
                   atlassify-app
                 </span>
@@ -4078,7 +4082,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 class="css-1w1rt7h"
               >
                 <div
-                  aria-labelledby="118"
+                  aria-labelledby="170"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -4096,7 +4100,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="118"
+                    id="170"
                   >
                     Atlassify Home
                   </span>

--- a/src/components/notifications/__snapshots__/AccountNotifications.test.tsx.snap
+++ b/src/components/notifications/__snapshots__/AccountNotifications.test.tsx.snap
@@ -2804,7 +2804,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   type="button"
                 >
                   <div
-                    aria-labelledby="134"
+                    aria-labelledby="110"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -2822,7 +2822,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="134"
+                      id="110"
                     >
                       Atlassify
                     </span>
@@ -3001,7 +3001,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   type="button"
                 >
                   <div
-                    aria-labelledby="154"
+                    aria-labelledby="130"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -3019,7 +3019,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="154"
+                      id="130"
                     >
                       Atlassify
                     </span>
@@ -3188,7 +3188,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 role="presentation"
               >
                 <div
-                  aria-labelledby="162"
+                  aria-labelledby="138"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3206,7 +3206,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="162"
+                    id="138"
                   >
                     atlassify-app
                   </span>
@@ -3266,7 +3266,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   class="css-1w1rt7h"
                 >
                   <div
-                    aria-labelledby="164"
+                    aria-labelledby="140"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -3284,7 +3284,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="164"
+                      id="140"
                     >
                       #103: chore(deps): update dependency eslint
                     </span>
@@ -3394,7 +3394,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 role="presentation"
               >
                 <div
-                  aria-labelledby="168"
+                  aria-labelledby="144"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3412,7 +3412,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="168"
+                    id="144"
                   >
                     atlassify-app
                   </span>
@@ -3472,7 +3472,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   class="css-1w1rt7h"
                 >
                   <div
-                    aria-labelledby="170"
+                    aria-labelledby="146"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -3490,7 +3490,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="170"
+                      id="146"
                     >
                       Atlassify Home
                     </span>
@@ -3611,7 +3611,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 type="button"
               >
                 <div
-                  aria-labelledby="154"
+                  aria-labelledby="130"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3629,7 +3629,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="154"
+                    id="130"
                   >
                     Atlassify
                   </span>
@@ -3798,7 +3798,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
               role="presentation"
             >
               <div
-                aria-labelledby="162"
+                aria-labelledby="138"
                 role="img"
                 style="display: inline-block; position: relative; outline: 0;"
               >
@@ -3816,7 +3816,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 </span>
                 <span
                   hidden=""
-                  id="162"
+                  id="138"
                 >
                   atlassify-app
                 </span>
@@ -3876,7 +3876,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 class="css-1w1rt7h"
               >
                 <div
-                  aria-labelledby="164"
+                  aria-labelledby="140"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3894,7 +3894,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="164"
+                    id="140"
                   >
                     #103: chore(deps): update dependency eslint
                   </span>
@@ -4004,7 +4004,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
               role="presentation"
             >
               <div
-                aria-labelledby="168"
+                aria-labelledby="144"
                 role="img"
                 style="display: inline-block; position: relative; outline: 0;"
               >
@@ -4022,7 +4022,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 </span>
                 <span
                   hidden=""
-                  id="168"
+                  id="144"
                 >
                   atlassify-app
                 </span>
@@ -4082,7 +4082,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 class="css-1w1rt7h"
               >
                 <div
-                  aria-labelledby="170"
+                  aria-labelledby="146"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -4100,7 +4100,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="170"
+                    id="146"
                   >
                     Atlassify Home
                   </span>


### PR DESCRIPTION
To avoid rushed mistakes, added a confirmation prompt so that the user can decide whether to actually mark all notifications as read or not

![image](https://github.com/user-attachments/assets/aaaa1de0-082f-46d1-8829-0654311f1573)

### Open Items:
1. **_[FIXED]_** Somehow, the show/hide account notifications action is also getting triggered along with the "Mark all as Read" action (and also upon clicking anywhere inside the modal. Basically, you can collapse/expand the accounts panel by clicking inside the "Are you sure" modal). Need to check this
2. The `xcss` styles for the modal were a copy-paste from `Settings.tsx`. If it's better to keep those in a common file, can take a look

### Possible Extension:
1. Adding this confirmation modal for the "Mark Product Notifications As Read" action too (is it too intrusive? any value?)