### PR TITLE
feat(settings): sort grouped notifications alphabetically 

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -2,6 +2,9 @@ name: Triage PR
 
 on:
   pull_request_target:
+    types: [opened, edited, synchronize, ready_for_review]
+    branches: [main]
+
   
 permissions:
   contents: read # the config file

--- a/src/__mocks__/state-mocks.ts
+++ b/src/__mocks__/state-mocks.ts
@@ -1,11 +1,15 @@
 import {
   type Account,
+  type AppearanceSettingsState,
   type AtlassifyState,
   type AuthState,
   type EncryptedToken,
+  type FilterSettingsState,
   type Link,
+  type NotificationSettingsState,
   OpenPreference,
   type SettingsState,
+  type SystemSettingsState,
   Theme,
   type Username,
 } from '../types';
@@ -22,19 +26,20 @@ export const mockAuth: AuthState = {
   accounts: [mockAtlassianCloudAccount],
 };
 
-const mockAppearanceSettings = {
+const mockAppearanceSettings: AppearanceSettingsState = {
   theme: Theme.LIGHT,
   zoomPercentage: 100,
 };
 
-const mockNotificationSettings = {
+const mockNotificationSettings: NotificationSettingsState = {
   markAsReadOnOpen: true,
   delayNotificationState: false,
   fetchOnlyUnreadNotifications: true,
   groupNotificationsByProduct: false,
+  groupNotificationsByProductAlphabetically: false,
 };
 
-const mockSystemSettings = {
+const mockSystemSettings: SystemSettingsState = {
   openLinks: OpenPreference.FOREGROUND,
   keyboardShortcutEnabled: true,
   showNotificationsCountInTray: true,
@@ -44,7 +49,7 @@ const mockSystemSettings = {
   openAtStartup: false,
 };
 
-const mockFilters = {
+const mockFilters: FilterSettingsState = {
   filterCategories: [],
   filterReadStates: [],
   filterProducts: [],

--- a/src/components/notifications/AccountNotifications.test.tsx
+++ b/src/components/notifications/AccountNotifications.test.tsx
@@ -40,7 +40,7 @@ describe('components/notifications/AccountNotifications.tsx', () => {
       expect(tree).toMatchSnapshot();
     });
 
-    it('should render itself - group notifications by products', () => {
+    it('should render itself - group notifications by products - ordered by datetime', () => {
       const props = {
         account: mockAtlassianCloudAccount,
         notifications: mockAtlassifyNotifications,
@@ -50,7 +50,35 @@ describe('components/notifications/AccountNotifications.tsx', () => {
       const tree = render(
         <AppContext.Provider
           value={{
-            settings: { ...mockSettings, groupNotificationsByProduct: true },
+            settings: {
+              ...mockSettings,
+              groupNotificationsByProduct: true,
+              groupNotificationsByProductAlphabetically: false,
+            },
+          }}
+        >
+          <AccountNotifications {...props} />
+        </AppContext.Provider>,
+      );
+
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render itself - group notifications by products - ordered by products alphabetically', () => {
+      const props = {
+        account: mockAtlassianCloudAccount,
+        notifications: mockAtlassifyNotifications,
+        error: null,
+      };
+
+      const tree = render(
+        <AppContext.Provider
+          value={{
+            settings: {
+              ...mockSettings,
+              groupNotificationsByProduct: true,
+              groupNotificationsByProductAlphabetically: true,
+            },
           }}
         >
           <AccountNotifications {...props} />

--- a/src/components/notifications/AccountNotifications.tsx
+++ b/src/components/notifications/AccountNotifications.tsx
@@ -80,7 +80,13 @@ export const AccountNotifications: FC<IAccountNotifications> = (
       },
       {},
     ),
-  ).sort((a, b) => a[0].product.name.localeCompare(b[0].product.name));
+  );
+
+  if (settings.groupNotificationsByProductAlphabetically) {
+    groupedNotifications.sort((a, b) =>
+      a[0].product.name.localeCompare(b[0].product.name),
+    );
+  }
 
   const toggleAccountNotifications = () => {
     setShowAccountNotifications(!showAccountNotifications);

--- a/src/components/notifications/__snapshots__/AccountNotifications.test.tsx.snap
+++ b/src/components/notifications/__snapshots__/AccountNotifications.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`components/notifications/AccountNotifications.tsx account view types sh
                   type="button"
                 >
                   <div
-                    aria-labelledby="38"
+                    aria-labelledby="46"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -44,7 +44,7 @@ exports[`components/notifications/AccountNotifications.tsx account view types sh
                     </span>
                     <span
                       hidden=""
-                      id="38"
+                      id="46"
                     >
                       Atlassify
                     </span>
@@ -262,7 +262,7 @@ exports[`components/notifications/AccountNotifications.tsx account view types sh
                 type="button"
               >
                 <div
-                  aria-labelledby="38"
+                  aria-labelledby="46"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -280,7 +280,7 @@ exports[`components/notifications/AccountNotifications.tsx account view types sh
                   </span>
                   <span
                     hidden=""
-                    id="38"
+                    id="46"
                   >
                     Atlassify
                   </span>
@@ -529,7 +529,7 @@ exports[`components/notifications/AccountNotifications.tsx account view types sh
 }
 `;
 
-exports[`components/notifications/AccountNotifications.tsx account view types should render itself - group notifications by products 1`] = `
+exports[`components/notifications/AccountNotifications.tsx account view types should render itself - group notifications by products - ordered by datetime 1`] = `
 {
   "asFragment": [Function],
   "baseElement": <body>
@@ -994,7 +994,7 @@ exports[`components/notifications/AccountNotifications.tsx account view types sh
 }
 `;
 
-exports[`components/notifications/AccountNotifications.tsx account view types should render itself - no notifications 1`] = `
+exports[`components/notifications/AccountNotifications.tsx account view types should render itself - group notifications by products - ordered by products alphabetically 1`] = `
 {
   "asFragment": [Function],
   "baseElement": <body>
@@ -1039,6 +1039,471 @@ exports[`components/notifications/AccountNotifications.tsx account view types sh
                     <span
                       hidden=""
                       id="30"
+                    >
+                      Atlassify
+                    </span>
+                  </div>
+                  <div
+                    class="css-1orugy9"
+                  >
+                    <span
+                      class="css-pbo52v"
+                    >
+                      Atlassify
+                    </span>
+                    <span
+                      class="css-km389f"
+                    />
+                  </div>
+                </button>
+              </div>
+               
+              <span
+                class="css-g73hg0"
+              >
+                <span
+                  class="css-pvol9p"
+                >
+                  2
+                </span>
+              </span>
+            </div>
+            <div
+              class="css-gokkc4"
+            >
+              <div
+                role="presentation"
+              >
+                <button
+                  class=" css-a8hcye"
+                  data-testid="account-pull-requests"
+                  type="button"
+                >
+                  <span
+                    class=" css-1spmf3f"
+                  >
+                    <span
+                      class="css-1ka881b"
+                      style="--logo-color: inherit; --logo-fill: currentColor;"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="none"
+                        focusable="false"
+                        height="32"
+                        viewBox="0 0 32 32"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        
+      
+                        <path
+                          d="m25.586 15.819-1.618 9.885c-.106.598-.528.95-1.126.95H9.122c-.598 0-1.02-.352-1.126-.95L5.146 8.08c-.105-.598.212-.985.775-.985h20.123c.562 0 .88.387.773.985l-.773 4.644c-.106.668-.493.95-1.126.95H12.816c-.176 0-.282.105-.246.316l.95 5.84c.035.14.14.246.281.246h4.362c.141 0 .246-.105.282-.246l.668-4.222c.07-.527.422-.738.915-.738h4.75c.703 0 .914.351.808.95"
+                          fill="inherit"
+                        />
+                        
+    
+                      </svg>
+                    </span>
+                    <span
+                      class="css-b5o75w"
+                    >
+                      My pull requests
+                    </span>
+                  </span>
+                </button>
+              </div>
+              <div
+                role="presentation"
+              >
+                <button
+                  class=" css-a8hcye"
+                  data-testid="account-mark-as-read"
+                  type="button"
+                >
+                  <span
+                    class=" css-1spmf3f"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="css-1wits42"
+                      data-vc="icon-undefined"
+                      style="--icon-primary-color: currentColor; --icon-secondary-color: var(--ds-surface, #FFFFFF);"
+                    >
+                      <svg
+                        height="24"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                        width="24"
+                      >
+                        <circle
+                          cx="12"
+                          cy="12"
+                          fill="currentcolor"
+                          fill-rule="evenodd"
+                          r="5"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="css-b5o75w"
+                    >
+                      Mark all account notifications as read
+                    </span>
+                  </span>
+                </button>
+              </div>
+              <div
+                role="presentation"
+              >
+                <button
+                  class=" css-a8hcye"
+                  data-testid="account-toggle"
+                  type="button"
+                >
+                  <span
+                    class=" css-1spmf3f"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="css-snhnyn"
+                      data-vc="icon-undefined"
+                      style="--icon-primary-color: currentColor; --icon-secondary-color: var(--ds-surface, #FFFFFF);"
+                    >
+                      <svg
+                        height="24"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                        width="24"
+                      >
+                        <path
+                          d="M8.292 10.293a1.01 1.01 0 0 0 0 1.419l2.939 2.965c.218.215.5.322.779.322s.556-.107.769-.322l2.93-2.955a1.01 1.01 0 0 0 0-1.419.987.987 0 0 0-1.406 0l-2.298 2.317-2.307-2.327a.99.99 0 0 0-1.406 0"
+                          fill="currentcolor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="css-b5o75w"
+                    >
+                      Hide account notifications
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          Product Notifications
+        </div>
+        <div>
+          Product Notifications
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="css-1npayr"
+    >
+      <div
+        class="css-41uoy6"
+      >
+        <div
+          class="css-1a0x9v0"
+        >
+          <div
+            class="css-1v6wdk"
+          >
+            <div
+              role="presentation"
+            >
+              <button
+                class="css-1xq1pkg"
+                data-testid="account-profile--itemInner"
+                type="button"
+              >
+                <div
+                  aria-labelledby="30"
+                  role="img"
+                  style="display: inline-block; position: relative; outline: 0;"
+                >
+                  <span
+                    class="css-vucx95"
+                  >
+                    <img
+                      alt=""
+                      aria-hidden="true"
+                      class="css-13ep12v"
+                      data-vc="avatar-image"
+                      src="https://avatar.atlassify.io"
+                      style="border-radius: 50%;"
+                    />
+                  </span>
+                  <span
+                    hidden=""
+                    id="30"
+                  >
+                    Atlassify
+                  </span>
+                </div>
+                <div
+                  class="css-1orugy9"
+                >
+                  <span
+                    class="css-pbo52v"
+                  >
+                    Atlassify
+                  </span>
+                  <span
+                    class="css-km389f"
+                  />
+                </div>
+              </button>
+            </div>
+             
+            <span
+              class="css-g73hg0"
+            >
+              <span
+                class="css-pvol9p"
+              >
+                2
+              </span>
+            </span>
+          </div>
+          <div
+            class="css-gokkc4"
+          >
+            <div
+              role="presentation"
+            >
+              <button
+                class=" css-a8hcye"
+                data-testid="account-pull-requests"
+                type="button"
+              >
+                <span
+                  class=" css-1spmf3f"
+                >
+                  <span
+                    class="css-1ka881b"
+                    style="--logo-color: inherit; --logo-fill: currentColor;"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      focusable="false"
+                      height="32"
+                      viewBox="0 0 32 32"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      
+      
+                      <path
+                        d="m25.586 15.819-1.618 9.885c-.106.598-.528.95-1.126.95H9.122c-.598 0-1.02-.352-1.126-.95L5.146 8.08c-.105-.598.212-.985.775-.985h20.123c.562 0 .88.387.773.985l-.773 4.644c-.106.668-.493.95-1.126.95H12.816c-.176 0-.282.105-.246.316l.95 5.84c.035.14.14.246.281.246h4.362c.141 0 .246-.105.282-.246l.668-4.222c.07-.527.422-.738.915-.738h4.75c.703 0 .914.351.808.95"
+                        fill="inherit"
+                      />
+                      
+    
+                    </svg>
+                  </span>
+                  <span
+                    class="css-b5o75w"
+                  >
+                    My pull requests
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
+              role="presentation"
+            >
+              <button
+                class=" css-a8hcye"
+                data-testid="account-mark-as-read"
+                type="button"
+              >
+                <span
+                  class=" css-1spmf3f"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="css-1wits42"
+                    data-vc="icon-undefined"
+                    style="--icon-primary-color: currentColor; --icon-secondary-color: var(--ds-surface, #FFFFFF);"
+                  >
+                    <svg
+                      height="24"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                      width="24"
+                    >
+                      <circle
+                        cx="12"
+                        cy="12"
+                        fill="currentcolor"
+                        fill-rule="evenodd"
+                        r="5"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-b5o75w"
+                  >
+                    Mark all account notifications as read
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
+              role="presentation"
+            >
+              <button
+                class=" css-a8hcye"
+                data-testid="account-toggle"
+                type="button"
+              >
+                <span
+                  class=" css-1spmf3f"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="css-snhnyn"
+                    data-vc="icon-undefined"
+                    style="--icon-primary-color: currentColor; --icon-secondary-color: var(--ds-surface, #FFFFFF);"
+                  >
+                    <svg
+                      height="24"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                      width="24"
+                    >
+                      <path
+                        d="M8.292 10.293a1.01 1.01 0 0 0 0 1.419l2.939 2.965c.218.215.5.322.779.322s.556-.107.769-.322l2.93-2.955a1.01 1.01 0 0 0 0-1.419.987.987 0 0 0-1.406 0l-2.298 2.317-2.307-2.327a.99.99 0 0 0-1.406 0"
+                        fill="currentcolor"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-b5o75w"
+                  >
+                    Hide account notifications
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        Product Notifications
+      </div>
+      <div>
+        Product Notifications
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`components/notifications/AccountNotifications.tsx account view types should render itself - no notifications 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="css-1npayr"
+      >
+        <div
+          class="css-41uoy6"
+        >
+          <div
+            class="css-1a0x9v0"
+          >
+            <div
+              class="css-1v6wdk"
+            >
+              <div
+                role="presentation"
+              >
+                <button
+                  class="css-1xq1pkg"
+                  data-testid="account-profile--itemInner"
+                  type="button"
+                >
+                  <div
+                    aria-labelledby="38"
+                    role="img"
+                    style="display: inline-block; position: relative; outline: 0;"
+                  >
+                    <span
+                      class="css-vucx95"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        class="css-13ep12v"
+                        data-vc="avatar-image"
+                        src="https://avatar.atlassify.io"
+                        style="border-radius: 50%;"
+                      />
+                    </span>
+                    <span
+                      hidden=""
+                      id="38"
                     >
                       Atlassify
                     </span>
@@ -1243,7 +1708,7 @@ exports[`components/notifications/AccountNotifications.tsx account view types sh
                 type="button"
               >
                 <div
-                  aria-labelledby="30"
+                  aria-labelledby="38"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -1261,7 +1726,7 @@ exports[`components/notifications/AccountNotifications.tsx account view types sh
                   </span>
                   <span
                     hidden=""
-                    id="30"
+                    id="38"
                   >
                     Atlassify
                   </span>
@@ -2804,7 +3269,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   type="button"
                 >
                   <div
-                    aria-labelledby="110"
+                    aria-labelledby="118"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -2822,7 +3287,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="110"
+                      id="118"
                     >
                       Atlassify
                     </span>
@@ -3001,7 +3466,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   type="button"
                 >
                   <div
-                    aria-labelledby="130"
+                    aria-labelledby="138"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -3019,7 +3484,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="130"
+                      id="138"
                     >
                       Atlassify
                     </span>
@@ -3188,7 +3653,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 role="presentation"
               >
                 <div
-                  aria-labelledby="138"
+                  aria-labelledby="146"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3206,7 +3671,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="138"
+                    id="146"
                   >
                     atlassify-app
                   </span>
@@ -3266,7 +3731,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   class="css-1w1rt7h"
                 >
                   <div
-                    aria-labelledby="140"
+                    aria-labelledby="148"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -3284,7 +3749,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="140"
+                      id="148"
                     >
                       #103: chore(deps): update dependency eslint
                     </span>
@@ -3394,7 +3859,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 role="presentation"
               >
                 <div
-                  aria-labelledby="144"
+                  aria-labelledby="152"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3412,7 +3877,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="144"
+                    id="152"
                   >
                     atlassify-app
                   </span>
@@ -3472,7 +3937,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   class="css-1w1rt7h"
                 >
                   <div
-                    aria-labelledby="146"
+                    aria-labelledby="154"
                     role="img"
                     style="display: inline-block; position: relative; outline: 0;"
                   >
@@ -3490,7 +3955,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                     </span>
                     <span
                       hidden=""
-                      id="146"
+                      id="154"
                     >
                       Atlassify Home
                     </span>
@@ -3611,7 +4076,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 type="button"
               >
                 <div
-                  aria-labelledby="130"
+                  aria-labelledby="138"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3629,7 +4094,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="130"
+                    id="138"
                   >
                     Atlassify
                   </span>
@@ -3798,7 +4263,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
               role="presentation"
             >
               <div
-                aria-labelledby="138"
+                aria-labelledby="146"
                 role="img"
                 style="display: inline-block; position: relative; outline: 0;"
               >
@@ -3816,7 +4281,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 </span>
                 <span
                   hidden=""
-                  id="138"
+                  id="146"
                 >
                   atlassify-app
                 </span>
@@ -3876,7 +4341,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 class="css-1w1rt7h"
               >
                 <div
-                  aria-labelledby="140"
+                  aria-labelledby="148"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -3894,7 +4359,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="140"
+                    id="148"
                   >
                     #103: chore(deps): update dependency eslint
                   </span>
@@ -4004,7 +4469,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
               role="presentation"
             >
               <div
-                aria-labelledby="144"
+                aria-labelledby="152"
                 role="img"
                 style="display: inline-block; position: relative; outline: 0;"
               >
@@ -4022,7 +4487,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 </span>
                 <span
                   hidden=""
-                  id="144"
+                  id="152"
                 >
                   atlassify-app
                 </span>
@@ -4082,7 +4547,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                 class="css-1w1rt7h"
               >
                 <div
-                  aria-labelledby="146"
+                  aria-labelledby="154"
                   role="img"
                   style="display: inline-block; position: relative; outline: 0;"
                 >
@@ -4100,7 +4565,7 @@ exports[`components/notifications/AccountNotifications.tsx should toggle account
                   </span>
                   <span
                     hidden=""
-                    id="146"
+                    id="154"
                   >
                     Atlassify Home
                   </span>

--- a/src/components/settings/NotificationSettings.test.tsx
+++ b/src/components/settings/NotificationSettings.test.tsx
@@ -36,6 +36,37 @@ describe('routes/components/settings/NotificationSettings.tsx', () => {
     expect(updateSetting).toHaveBeenCalledWith('markAsReadOnOpen', false);
   });
 
+  it('should toggle the sortGroupedNotificationsByProductAlphabetically checkbox', async () => {
+    await act(async () => {
+      render(
+        <AppContext.Provider
+          value={{
+            auth: mockAuth,
+            settings: mockSettings,
+            updateSetting,
+          }}
+        >
+          <MemoryRouter>
+            <NotificationSettings />
+          </MemoryRouter>
+        </AppContext.Provider>,
+      );
+    });
+
+    fireEvent.click(
+      screen.getByLabelText('Group product notifications alphabetically'),
+      {
+        target: { checked: true },
+      },
+    );
+
+    expect(updateSetting).toHaveBeenCalledTimes(1);
+    expect(updateSetting).toHaveBeenCalledWith(
+      'groupNotificationsByProductAlphabetically',
+      false,
+    );
+  });
+
   it('should toggle the delayNotificationState checkbox', async () => {
     await act(async () => {
       render(

--- a/src/components/settings/NotificationSettings.tsx
+++ b/src/components/settings/NotificationSettings.tsx
@@ -23,6 +23,18 @@ export const NotificationSettings: FC = () => {
         }
       />
 
+      <Checkbox
+        name="groupNotificationsByProductAlphabetically"
+        label="Group product notifications alphabetically"
+        isChecked={settings.groupNotificationsByProductAlphabetically}
+        onChange={(evt) =>
+          updateSetting(
+            'groupNotificationsByProductAlphabetically',
+            evt.target.checked,
+          )
+        }
+      />
+
       <Inline space="space.100">
         <Checkbox
           name="delayNotificationState"

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -12,13 +12,17 @@ import { useNotifications } from '../hooks/useNotifications';
 import {
   type Account,
   type AccountNotifications,
+  type AppearanceSettingsState,
   type AtlassifyError,
   type AtlassifyNotification,
   type AuthState,
+  type FilterSettingsState,
+  type NotificationSettingsState,
   OpenPreference,
   type SettingsState,
   type SettingsValue,
   type Status,
+  type SystemSettingsState,
   Theme,
 } from '../types';
 import type { LoginOptions } from '../utils/auth/types';
@@ -47,19 +51,20 @@ export const defaultAuth: AuthState = {
   accounts: [],
 };
 
-const defaultAppearanceSettings = {
+const defaultAppearanceSettings: AppearanceSettingsState = {
   theme: Theme.LIGHT,
   zoomPercentage: 100,
 };
 
-const defaultNotificationSettings = {
+const defaultNotificationSettings: NotificationSettingsState = {
   markAsReadOnOpen: true,
   delayNotificationState: false,
   fetchOnlyUnreadNotifications: true,
   groupNotificationsByProduct: false,
+  groupNotificationsByProductAlphabetically: false,
 };
 
-const defaultSystemSettings = {
+const defaultSystemSettings: SystemSettingsState = {
   openLinks: OpenPreference.FOREGROUND,
   keyboardShortcutEnabled: true,
   showNotificationsCountInTray: true,
@@ -69,7 +74,7 @@ const defaultSystemSettings = {
   openAtStartup: false,
 };
 
-export const defaultFilters = {
+export const defaultFilters: FilterSettingsState = {
   filterCategories: [],
   filterReadStates: [],
   filterProducts: [],

--- a/src/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/routes/__snapshots__/Settings.test.tsx.snap
@@ -340,6 +340,41 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
               Mark as read on open
             </span>
           </label>
+          <label
+            class="css-k8x29e"
+          >
+            <input
+              class="css-f3myyk"
+              name="groupNotificationsByProductAlphabetically"
+              tabindex="0"
+              type="checkbox"
+              value=""
+            />
+            <svg
+              class="css-1dr55qw"
+              role="presentation"
+              style="fill: var(--checkbox-tick-color);"
+              viewBox="0 0 24 24"
+            >
+              <g
+                fill-rule="evenodd"
+              >
+                <rect
+                  fill="currentColor"
+                  height="12"
+                  rx="2"
+                  width="12"
+                  x="6"
+                  y="6"
+                />
+              </g>
+            </svg>
+            <span
+              class="css-1odt9zb"
+            >
+              Group product notifications alphabetically
+            </span>
+          </label>
           <div
             class="css-gokkc4"
           >

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ export type SettingsState = AppearanceSettingsState &
 /**
  * Settings related to the appearance of the application.
  */
-interface AppearanceSettingsState {
+export interface AppearanceSettingsState {
   /**
    * The theme of the application.
    */
@@ -99,7 +99,7 @@ interface AppearanceSettingsState {
 /**
  * Settings related to the notifications within the application.
  */
-interface NotificationSettingsState {
+export interface NotificationSettingsState {
   /**
    * Whether to mark notifications as read when they are opened.
    */
@@ -119,12 +119,17 @@ interface NotificationSettingsState {
    * Whether to group notifications by product.
    */
   groupNotificationsByProduct: boolean;
+
+  /**
+   * Whether to sort grouped notifications by product alphabetically or time.
+   */
+  groupNotificationsByProductAlphabetically: boolean;
 }
 
 /**
  * Settings related to the system behavior of the application.
  */
-interface SystemSettingsState {
+export interface SystemSettingsState {
   /**
    * The preference for opening links upon notification interactions
    */
@@ -164,7 +169,7 @@ interface SystemSettingsState {
 /**
  * Settings related to the filtering of notifications within the application.
  */
-interface FilterSettingsState {
+export interface FilterSettingsState {
   /**
    * The categories to filter notifications by.
    */


### PR DESCRIPTION
Make the `group by product` ordering user controlled.

By default, it will sort by the latest notification timestamp,  Optionally, users can sort by product name (alphabetically)