### PR TITLE
fix: notification animation based on mark as read setting

### DIFF
--- a/src/renderer/components/notifications/NotificationRow.tsx
+++ b/src/renderer/components/notifications/NotificationRow.tsx
@@ -31,7 +31,9 @@ export const NotificationRow: FC<INotificationRow> = ({
 
   const handleNotificationInteraction = useCallback(() => {
     setAnimateExit(
-      settings.fetchOnlyUnreadNotifications && !settings.delayNotificationState,
+      settings.fetchOnlyUnreadNotifications &&
+        !settings.delayNotificationState &&
+        settings.markAsReadOnOpen,
     );
 
     if (settings.markAsReadOnOpen) {


### PR DESCRIPTION
When the mark as read setting is off, the swipe right animation on notifications should not occur, since the notification should not be set to read

resolves #192 