### PR TITLE
feat: Add Developer Menu Option to View Application Logs

### DIFF
--- a/docs/src/components/solid/FaqAccordion.tsx
+++ b/docs/src/components/solid/FaqAccordion.tsx
@@ -19,7 +19,7 @@ const content = [
 		question:
 			"Something is not working as expected, how can I debug Atlassify?",
 		answer:
-			"Using **Chrome Developer Tools** (console logs, network requests, etc):\n- All platforms: right click tray icon then _Developer → Toggle Developer Tools_\n- macOS: `command + opt + i`\n- Windows + Linux: `ctrl + shift + i`\n\nUsing **Application Log Files**:\n- macOS: `~/Library/Logs/atlassify`\n- Windows: `%USERPROFILE%\\AppData\\Roaming\\atlassify`",
+			"Using **Chrome Developer Tools** (console logs, network requests, etc):\n- All platforms: right click tray icon then _Developer → Toggle Developer Tools_\n- macOS: `command + opt + i`\n- Windows + Linux: `ctrl + shift + i`\n\nUsing **Application Log Files**:\n- All platforms: right click tray icon then _Developer → View Application Logs_\n- macOS: `~/Library/Logs/atlassify`\n- Windows: `%USERPROFILE%\\AppData\\Roaming\\atlassify`",
 	},
 	{
 		id: "4",

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -2,7 +2,7 @@ import { Menu, MenuItem } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import type { Menubar } from 'menubar';
 
-import { resetApp, takeScreenshot } from './utils';
+import { openLogsDirectory, resetApp, takeScreenshot } from './utils';
 
 export default class MenuBuilder {
   private readonly checkForUpdatesMenuItem: MenuItem;
@@ -59,6 +59,10 @@ export default class MenuBuilder {
             label: 'Take Screenshot',
             accelerator: 'CommandOrControl+S',
             click: () => takeScreenshot(this.menubar),
+          },
+          {
+            label: 'View Application Logs',
+            click: () => openLogsDirectory(),
           },
           {
             label: 'Reset App',

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
 import os from 'node:os';
+import path from 'node:path';
 import { dialog, shell } from 'electron';
 import log from 'electron-log';
 import type { Menubar } from 'menubar';
-import { logDirectoryPaths } from '../renderer/utils/platform';
 
 export function takeScreenshot(mb: Menubar) {
   const date = new Date();
@@ -38,12 +38,10 @@ export function resetApp(mb: Menubar) {
 }
 
 export function openLogsDirectory() {
-  const logDirectory = logDirectoryPaths[process.platform];
+  const logDirectory = path.dirname(log.transports.file?.getFile()?.path);
 
   if (!logDirectory) {
-    log.error(
-      `Unsupported platform: ${process.platform}! Cannot open logs directory`,
-    );
+    log.error('Could not find log directory!');
     return;
   }
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,8 +1,9 @@
 import fs from 'node:fs';
 import os from 'node:os';
-import { dialog } from 'electron';
+import { dialog, shell } from 'electron';
 import log from 'electron-log';
 import type { Menubar } from 'menubar';
+import { logDirectoryPaths } from '../renderer/utils/platform';
 
 export function takeScreenshot(mb: Menubar) {
   const date = new Date();
@@ -34,4 +35,17 @@ export function resetApp(mb: Menubar) {
     mb.window.webContents.send('atlassify:reset-app');
     mb.app.quit();
   }
+}
+
+export function openLogsDirectory() {
+  const logDirectory = logDirectoryPaths[process.platform];
+
+  if (!logDirectory) {
+    log.error(
+      `Unsupported platform: ${process.platform}! Cannot open logs directory`,
+    );
+    return;
+  }
+
+  shell.openPath(logDirectory);
 }

--- a/src/renderer/utils/constants.ts
+++ b/src/renderer/utils/constants.ts
@@ -16,6 +16,8 @@ export const Constants = {
 
   DEFAULT_KEYBOARD_SHORTCUT: 'CommandOrControl+Shift+G',
 
+  APP_NAME: 'atlassify',
+
   ATLASSIAN_URLS: {
     API: 'https://team.atlassian.net/gateway/api/graphql' as Link,
     DOCS: {

--- a/src/renderer/utils/platform.ts
+++ b/src/renderer/utils/platform.ts
@@ -1,3 +1,7 @@
+import os from 'node:os';
+import path from 'node:path';
+import { Constants } from './constants';
+
 export function isLinux(): boolean {
   return process.platform === 'linux';
 }
@@ -9,3 +13,9 @@ export function isMacOS(): boolean {
 export function isWindows(): boolean {
   return process.platform === 'win32';
 }
+
+export const logDirectoryPaths = {
+  win32: path.join(process.env.APPDATA || '', Constants.APP_NAME),
+  darwin: path.join(os.homedir(), 'Library', 'Logs', Constants.APP_NAME),
+  linux: path.join(os.homedir(), '.config', Constants.APP_NAME, 'logs'),
+};

--- a/src/renderer/utils/platform.ts
+++ b/src/renderer/utils/platform.ts
@@ -1,7 +1,3 @@
-import os from 'node:os';
-import path from 'node:path';
-import { Constants } from './constants';
-
 export function isLinux(): boolean {
   return process.platform === 'linux';
 }
@@ -13,9 +9,3 @@ export function isMacOS(): boolean {
 export function isWindows(): boolean {
   return process.platform === 'win32';
 }
-
-export const logDirectoryPaths = {
-  win32: path.join(process.env.APPDATA || '', Constants.APP_NAME),
-  darwin: path.join(os.homedir(), 'Library', 'Logs', Constants.APP_NAME),
-  linux: path.join(os.homedir(), '.config', Constants.APP_NAME, 'logs'),
-};


### PR DESCRIPTION
This option opens the logs directory appropriate to the user's operating system

![image](https://github.com/user-attachments/assets/4f12ee9d-440d-4272-8b15-8e0af669102b)

_**Note**: Have not tested this in Linux or Windows_ 😬