### PR TITLE
feat: combine unread/read toggle into standard filter option

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "@atlaskit/radio": "6.6.0",
     "@atlaskit/spinner": "16.3.4",
     "@atlaskit/textfield": "6.6.0",
-    "@atlaskit/toggle": "13.4.10",
     "@atlaskit/tokens": "2.5.0",
     "@atlaskit/tooltip": "18.9.4",
     "@biomejs/biome": "1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       '@atlaskit/textfield':
         specifier: 6.6.0
         version: 6.6.0(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@atlaskit/toggle':
-        specifier: 13.4.10
-        version: 13.4.10(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@atlaskit/tokens':
         specifier: 2.5.0
         version: 2.5.0(@types/react@18.3.18)(react@18.3.1)
@@ -438,11 +435,6 @@ packages:
 
   '@atlaskit/theme@14.0.0':
     resolution: {integrity: sha512-r5hYbLbxSJDqtMHJ7bCTSoFY8dnKpcFOUkcysjWtXkjbkXF1sM5ph0GD8lWmt9734soFNJNY+i4wo//CfTpcag==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-
-  '@atlaskit/toggle@13.4.10':
-    resolution: {integrity: sha512-xThhtN/OwhYyRcEMUg8zXDx7DWFMmaUOFSGxenFM+egLBxqjL+6tNWVk9YB0Bew5kXblIT84Ne1UgeYMDCLkEw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
@@ -5847,24 +5839,6 @@ snapshots:
       react: 18.3.1
     transitivePeerDependencies:
       - '@types/react'
-      - supports-color
-
-  '@atlaskit/toggle@13.4.10(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@atlaskit/analytics-next': 10.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@atlaskit/ds-lib': 3.3.0(@types/react@18.3.18)(react@18.3.1)
-      '@atlaskit/icon': 23.1.1(@types/react@18.3.18)(react@18.3.1)
-      '@atlaskit/platform-feature-flags': 0.3.0
-      '@atlaskit/primitives': 13.3.5(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@atlaskit/theme': 14.0.0(@types/react@18.3.18)(react@18.3.1)
-      '@atlaskit/tokens': 2.5.0(@types/react@18.3.18)(react@18.3.1)
-      '@babel/runtime': 7.25.7
-      '@emotion/react': 11.13.3(@types/react@18.3.18)(react@18.3.1)
-      bind-event-listener: 3.0.0
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
       - supports-color
 
   '@atlaskit/tokens@2.5.0(@types/react@18.3.18)(react@18.3.1)':

--- a/src/renderer/__mocks__/state-mocks.ts
+++ b/src/renderer/__mocks__/state-mocks.ts
@@ -51,7 +51,7 @@ const mockSystemSettings: SystemSettingsState = {
 const mockFilters: FilterSettingsState = {
   filterTimeSensitive: [],
   filterCategories: [],
-  filterReadStates: [],
+  filterReadStates: ['unread'],
   filterProducts: [],
 };
 

--- a/src/renderer/__mocks__/state-mocks.ts
+++ b/src/renderer/__mocks__/state-mocks.ts
@@ -34,7 +34,6 @@ const mockAppearanceSettings: AppearanceSettingsState = {
 const mockNotificationSettings: NotificationSettingsState = {
   markAsReadOnOpen: true,
   delayNotificationState: false,
-  fetchOnlyUnreadNotifications: true,
   groupNotificationsByProduct: false,
   groupNotificationsByProductAlphabetically: false,
 };

--- a/src/renderer/components/Sidebar.test.tsx
+++ b/src/renderer/components/Sidebar.test.tsx
@@ -218,34 +218,6 @@ describe('renderer/components/Sidebar.tsx', () => {
     });
   });
 
-  describe('show only unread notifications', () => {
-    it('should toggle show only unread notifications', () => {
-      render(
-        <AppContext.Provider
-          value={{
-            isLoggedIn: true,
-            notifications: [],
-            auth: mockAuth,
-            settings: mockSettings,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <Sidebar />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-
-      fireEvent.click(
-        screen.getByTestId('sidebar-toggle-unread-only--toggle-cross-icon'),
-      );
-
-      expect(
-        screen.getByTestId('sidebar-toggle-unread-only--input'),
-      ).toMatchSnapshot();
-    });
-  });
-
   describe('Group by products', () => {
     it('should order notifications by date', () => {
       render(

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -10,7 +10,6 @@ import RefreshIcon from '@atlaskit/icon/glyph/refresh';
 import SettingsIcon from '@atlaskit/icon/glyph/settings';
 import { Box, Stack } from '@atlaskit/primitives';
 import Spinner from '@atlaskit/spinner';
-import Toggle from '@atlaskit/toggle';
 import Tooltip from '@atlaskit/tooltip';
 
 import { colors } from '../../../tailwind.config';
@@ -114,25 +113,6 @@ export const Sidebar: FC = () => {
 
             {isLoggedIn && (
               <Fragment>
-                <Tooltip
-                  content="Show only unread notifications"
-                  position="right"
-                >
-                  <Toggle
-                    id="toggle-unread-only"
-                    size="regular"
-                    label="Show only unread toggle"
-                    isChecked={settings.fetchOnlyUnreadNotifications}
-                    onChange={async (evt) => {
-                      updateSetting(
-                        'fetchOnlyUnreadNotifications',
-                        evt.target.checked,
-                      );
-                    }}
-                    testId="sidebar-toggle-unread-only"
-                  />
-                </Tooltip>
-
                 <Tooltip
                   content="Group notifications by products"
                   position="right"

--- a/src/renderer/components/__snapshots__/AllRead.test.tsx.snap
+++ b/src/renderer/components/__snapshots__/AllRead.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`renderer/components/AllRead.tsx should render itself & its children - n
           <span
             class="text-xl font-semibold"
           >
-            No new notifications
+            No new filtered notifications
           </span>
         </div>
       </div>
@@ -54,7 +54,7 @@ exports[`renderer/components/AllRead.tsx should render itself & its children - n
         <span
           class="text-xl font-semibold"
         >
-          No new notifications
+          No new filtered notifications
         </span>
       </div>
     </div>

--- a/src/renderer/components/__snapshots__/Sidebar.test.tsx.snap
+++ b/src/renderer/components/__snapshots__/Sidebar.test.tsx.snap
@@ -3312,15 +3312,3 @@ exports[`renderer/components/Sidebar.tsx notifications icon renders correct icon
   </span>
 </button>
 `;
-
-exports[`renderer/components/Sidebar.tsx show only unread notifications should toggle show only unread notifications 1`] = `
-<input
-  aria-labelledby="uid92"
-  checked=""
-  data-testid="sidebar-toggle-unread-only--input"
-  id="toggle-unread-only"
-  name=""
-  type="checkbox"
-  value=""
-/>
-`;

--- a/src/renderer/components/__snapshots__/Sidebar.test.tsx.snap
+++ b/src/renderer/components/__snapshots__/Sidebar.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`renderer/components/Sidebar.tsx Filter notifications go to the filters route 1`] = `
 <button
-  class="css-1vyxgfe"
+  class="css-nmb8kj"
   data-testid="sidebar-filter-notifications"
   type="button"
 >
@@ -39,7 +39,7 @@ exports[`renderer/components/Sidebar.tsx Filter notifications go to the filters 
 
 exports[`renderer/components/Sidebar.tsx Filter notifications go to the home if filters path already shown 1`] = `
 <button
-  class="css-1vyxgfe"
+  class="css-nmb8kj"
   data-testid="sidebar-filter-notifications"
   type="button"
 >

--- a/src/renderer/components/notifications/NotificationRow.tsx
+++ b/src/renderer/components/notifications/NotificationRow.tsx
@@ -12,6 +12,7 @@ import { cn } from '../../utils/cn';
 import {
   FILTERS_READ_STATES,
   getCategoryFilterDetails,
+  isUnreadOnlyFilterSet,
 } from '../../utils/filters';
 import {
   formatNotificationFooterText,
@@ -34,7 +35,7 @@ export const NotificationRow: FC<INotificationRow> = ({
 
   const handleNotificationInteraction = useCallback(() => {
     setAnimateExit(
-      settings.fetchOnlyUnreadNotifications &&
+      isUnreadOnlyFilterSet(settings) &&
         !settings.delayNotificationState &&
         settings.markAsReadOnOpen,
     );
@@ -137,7 +138,7 @@ export const NotificationRow: FC<INotificationRow> = ({
                 appearance="subtle"
                 onClick={() => {
                   setAnimateExit(
-                    settings.fetchOnlyUnreadNotifications &&
+                    isUnreadOnlyFilterSet(settings) &&
                       !settings.delayNotificationState,
                   );
                   markNotificationsRead([notification]);

--- a/src/renderer/components/notifications/ProductNotifications.tsx
+++ b/src/renderer/components/notifications/ProductNotifications.tsx
@@ -9,6 +9,7 @@ import Tooltip from '@atlaskit/tooltip';
 import { AppContext } from '../../context/App';
 import type { AtlassifyNotification } from '../../types';
 import { openExternalLink } from '../../utils/comms';
+import { isUnreadOnlyFilterSet } from '../../utils/filters';
 import { formatProperCase, getChevronDetails } from '../../utils/helpers';
 import { getProductDetails } from '../../utils/products';
 import { isLightMode } from '../../utils/theme';
@@ -107,7 +108,7 @@ export const ProductNotifications: FC<IProductNotifications> = ({
                   // Don't trigger onClick of parent element.
                   event.stopPropagation();
                   setAnimateExit(
-                    settings.fetchOnlyUnreadNotifications &&
+                    isUnreadOnlyFilterSet(settings) &&
                       !settings.delayNotificationState,
                   );
                   markNotificationsRead(productNotifications);

--- a/src/renderer/components/notifications/__snapshots__/AccountNotifications.test.tsx.snap
+++ b/src/renderer/components/notifications/__snapshots__/AccountNotifications.test.tsx.snap
@@ -1686,7 +1686,7 @@ exports[`renderer/components/notifications/AccountNotifications.tsx account view
             <span
               class="text-xl font-semibold"
             >
-              No new notifications
+              No new filtered notifications
             </span>
           </div>
         </div>
@@ -1910,7 +1910,7 @@ exports[`renderer/components/notifications/AccountNotifications.tsx account view
           <span
             class="text-xl font-semibold"
           >
-            No new notifications
+            No new filtered notifications
           </span>
         </div>
       </div>

--- a/src/renderer/context/App.tsx
+++ b/src/renderer/context/App.tsx
@@ -61,7 +61,6 @@ const defaultAppearanceSettings: AppearanceSettingsState = {
 const defaultNotificationSettings: NotificationSettingsState = {
   markAsReadOnOpen: true,
   delayNotificationState: false,
-  fetchOnlyUnreadNotifications: true,
   groupNotificationsByProduct: false,
   groupNotificationsByProductAlphabetically: false,
 };
@@ -79,7 +78,7 @@ const defaultSystemSettings: SystemSettingsState = {
 export const defaultFilters: FilterSettingsState = {
   filterTimeSensitive: [],
   filterCategories: [],
-  filterReadStates: [],
+  filterReadStates: ['unread'],
   filterProducts: [],
 };
 
@@ -142,11 +141,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: We only want fetchNotifications to be called for certain changes
   useEffect(() => {
     fetchNotifications({ auth, settings });
-  }, [
-    auth.accounts,
-    settings.fetchOnlyUnreadNotifications,
-    settings.filterTimeSensitive,
-  ]);
+  }, [auth.accounts, settings.filterReadStates, settings.filterTimeSensitive]);
 
   useInterval(() => {
     fetchNotifications({ auth, settings });

--- a/src/renderer/hooks/useNotifications.test.ts
+++ b/src/renderer/hooks/useNotifications.test.ts
@@ -59,7 +59,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
     });
 
     it('fetchNotifications - all notifications read/unread', async () => {
-      mockState.settings.fetchOnlyUnreadNotifications = false;
+      mockState.settings.filterReadStates = ['read', 'unread'];
 
       nock('https://team.atlassian.net//')
         .post('gateway/api/graphql')
@@ -101,7 +101,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
     });
 
     it('fetchNotifications - handles missing extensions response object', async () => {
-      mockState.settings.fetchOnlyUnreadNotifications = false;
+      mockState.settings.filterReadStates = ['read', 'unread'];
 
       nock('https://team.atlassian.net//')
         .post('gateway/api/graphql')

--- a/src/renderer/hooks/useNotifications.ts
+++ b/src/renderer/hooks/useNotifications.ts
@@ -13,6 +13,7 @@ import {
   markNotificationsAsRead,
   markNotificationsAsUnread,
 } from '../utils/api/client';
+import { isUnreadOnlyFilterSet } from '../utils/filters';
 import { triggerNativeNotifications } from '../utils/notifications/native';
 import {
   getAllNotifications,
@@ -112,7 +113,7 @@ export const useNotifications = (): NotificationsState => {
         }
 
         // Only remove notifications from state if we're
-        if (state.settings.fetchOnlyUnreadNotifications) {
+        if (isUnreadOnlyFilterSet(state.settings)) {
           const updatedNotifications = removeNotifications(
             state.settings,
             readNotifications,

--- a/src/renderer/routes/Filters.test.tsx
+++ b/src/renderer/routes/Filters.test.tsx
@@ -192,10 +192,11 @@ describe('renderer/routes/Filters.tsx', () => {
           );
         });
 
-        fireEvent.click(screen.getByLabelText('unread'));
+        fireEvent.click(screen.getByLabelText('read'));
 
         expect(updateSetting).toHaveBeenCalledWith('filterReadStates', [
           'unread',
+          'read',
         ]);
       });
 

--- a/src/renderer/routes/__snapshots__/Filters.test.tsx.snap
+++ b/src/renderer/routes/__snapshots__/Filters.test.tsx.snap
@@ -428,6 +428,7 @@ exports[`renderer/routes/Filters.tsx General should render itself & its children
                   >
                     <input
                       aria-label="unread"
+                      checked=""
                       class="css-f3myyk"
                       name="unread"
                       tabindex="0"
@@ -451,6 +452,10 @@ exports[`renderer/routes/Filters.tsx General should render itself & its children
                           x="6"
                           y="6"
                         />
+                        <path
+                          d="M9.707 11.293a1 1 0 1 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 1 0-1.414-1.414L11 12.586l-1.293-1.293z"
+                          fill="inherit"
+                        />
                       </g>
                     </svg>
                     <span
@@ -460,10 +465,10 @@ exports[`renderer/routes/Filters.tsx General should render itself & its children
                     </span>
                   </label>
                   <span
-                    class="css-1wkl091"
+                    class="css-g73hg0"
                   >
                     <span
-                      class="css-f9etm4"
+                      class="css-pvol9p"
                     >
                       0
                     </span>
@@ -1773,6 +1778,7 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                   >
                     <input
                       aria-label="read"
+                      checked=""
                       class="css-f3myyk"
                       name="read"
                       tabindex="0"
@@ -1796,6 +1802,10 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                           x="6"
                           y="6"
                         />
+                        <path
+                          d="M9.707 11.293a1 1 0 1 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 1 0-1.414-1.414L11 12.586l-1.293-1.293z"
+                          fill="inherit"
+                        />
                       </g>
                     </svg>
                     <span
@@ -1805,10 +1815,10 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                     </span>
                   </label>
                   <span
-                    class="css-1wkl091"
+                    class="css-g73hg0"
                   >
                     <span
-                      class="css-f9etm4"
+                      class="css-pvol9p"
                     >
                       0
                     </span>

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -110,11 +110,6 @@ export interface NotificationSettingsState {
   delayNotificationState: boolean;
 
   /**
-   * Whether to fetch only unread notifications, or all notifications.
-   */
-  fetchOnlyUnreadNotifications: boolean;
-
-  /**
    * Whether to group notifications by product.
    */
   groupNotificationsByProduct: boolean;

--- a/src/renderer/utils/api/client.ts
+++ b/src/renderer/utils/api/client.ts
@@ -1,5 +1,6 @@
 import type { Account, SettingsState, Token, Username } from '../../types';
 import { Constants } from '../constants';
+import { isReadOnlyFilterSet, isUnreadOnlyFilterSet } from '../filters';
 import { graphql } from './graphql/generated/gql';
 import {
   InfluentsNotificationReadState,
@@ -83,11 +84,19 @@ export function getNotificationsForUser(
     }
   `);
 
+  let readStateQueryVariable = null;
+
+  if (isUnreadOnlyFilterSet(settings)) {
+    readStateQueryVariable = InfluentsNotificationReadState.Unread;
+  }
+
+  if (isReadOnlyFilterSet(settings)) {
+    readStateQueryVariable = InfluentsNotificationReadState.Read;
+  }
+
   return performPostRequest(account, MyNotificationsQuery, {
     first: Constants.MAX_NOTIFICATIONS_PER_ACCOUNT,
-    readState: settings.fetchOnlyUnreadNotifications
-      ? InfluentsNotificationReadState.Unread
-      : null,
+    readState: readStateQueryVariable,
   });
 }
 

--- a/src/renderer/utils/filters.test.ts
+++ b/src/renderer/utils/filters.test.ts
@@ -13,7 +13,15 @@ import {
 describe('renderer/utils/filters.ts', () => {
   describe('has filters', () => {
     it('default filter settings', () => {
-      expect(hasAnyFiltersSet(defaultSettings)).toBe(false);
+      expect(hasAnyFiltersSet(defaultSettings)).toBe(true);
+    });
+
+    it('no filters settings', () => {
+      const settings = {
+        ...defaultSettings,
+        filterReadStates: [],
+      } as SettingsState;
+      expect(hasAnyFiltersSet(settings)).toBe(false);
     });
 
     it('non-default time sensitive filters', () => {

--- a/src/renderer/utils/filters.ts
+++ b/src/renderer/utils/filters.ts
@@ -109,6 +109,20 @@ export function getReadStateFilterCount(
   );
 }
 
+export function isUnreadOnlyFilterSet(settings: SettingsState): boolean {
+  return (
+    settings.filterReadStates.length === 1 &&
+    settings.filterReadStates.includes('unread')
+  );
+}
+
+export function isReadOnlyFilterSet(settings: SettingsState): boolean {
+  return (
+    settings.filterReadStates.length === 1 &&
+    settings.filterReadStates.includes('read')
+  );
+}
+
 export function getProductFilterCount(
   notifications: AccountNotifications[],
   product: ProductName,


### PR DESCRIPTION
Prototype PR to explore collapsing the sidebar toggle for unread/read notification fetching to be controlled via the `Read State` Filters

This slightly deviates away from the way Atlassian have implemented their solution within https://team.atlassian.com/notifications

Seeking feedback from users.  I'm currently on the fence if I like this direction 🤔 