### PR TITLE
fix: prevent default filters from being overwritten

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 name: Triage PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: 
       - opened
       - edited

--- a/src/renderer/routes/Filters.tsx
+++ b/src/renderer/routes/Filters.tsx
@@ -5,7 +5,6 @@ import Button from '@atlaskit/button/new';
 import Checkbox from '@atlaskit/checkbox';
 import Heading from '@atlaskit/heading';
 import { Box, Inline, Stack } from '@atlaskit/primitives';
-import Tooltip from '@atlaskit/tooltip';
 
 import { Contents } from '../components/primitives/Contents';
 import { Footer } from '../components/primitives/Footer';
@@ -51,8 +50,9 @@ export const FiltersRoute: FC = () => {
     timeSensitive: TimeSensitiveFilterType,
     checked: boolean,
   ) => {
-    let timeSensitives: TimeSensitiveFilterType[] =
-      settings.filterTimeSensitive;
+    let timeSensitives: TimeSensitiveFilterType[] = [
+      ...settings.filterTimeSensitive,
+    ];
 
     if (checked) {
       timeSensitives.push(timeSensitive);
@@ -71,7 +71,7 @@ export const FiltersRoute: FC = () => {
     category: CategoryFilterType,
     checked: boolean,
   ) => {
-    let categories: CategoryFilterType[] = settings.filterCategories;
+    let categories: CategoryFilterType[] = [...settings.filterCategories];
 
     if (checked) {
       categories.push(category);
@@ -90,7 +90,7 @@ export const FiltersRoute: FC = () => {
     readState: ReadStateFilterType,
     checked: boolean,
   ) => {
-    let readStates: ReadStateFilterType[] = settings.filterReadStates;
+    let readStates: ReadStateFilterType[] = [...settings.filterReadStates];
 
     if (checked) {
       readStates.push(readState);
@@ -106,7 +106,7 @@ export const FiltersRoute: FC = () => {
   };
 
   const updateProductFilter = (product: ProductName, checked: boolean) => {
-    let products: ProductName[] = settings.filterProducts;
+    let products: ProductName[] = [...settings.filterProducts];
 
     if (checked) {
       products.push(product);
@@ -324,17 +324,15 @@ export const FiltersRoute: FC = () => {
       </Contents>
 
       <Footer justify="end">
-        <Tooltip content="Clear all filters" position="left">
-          <Button
-            title="Clear Filters"
-            onClick={clearFilters}
-            appearance="discovery"
-            spacing="compact"
-            testId="filters-clear"
-          >
-            Clear Filters
-          </Button>
-        </Tooltip>
+        <Button
+          title="Clear Filters"
+          onClick={clearFilters}
+          appearance="discovery"
+          spacing="compact"
+          testId="filters-clear"
+        >
+          Clear Filters
+        </Button>
       </Footer>
     </Page>
   );

--- a/src/renderer/routes/__snapshots__/Filters.test.tsx.snap
+++ b/src/renderer/routes/__snapshots__/Filters.test.tsx.snap
@@ -1256,22 +1256,18 @@ exports[`renderer/routes/Filters.tsx General should render itself & its children
     <div
       class="css-hugz22"
     >
-      <div
-        role="presentation"
+      <button
+        class="css-18yzeap"
+        data-testid="filters-clear"
+        title="Clear Filters"
+        type="button"
       >
-        <button
-          class="css-18yzeap"
-          data-testid="filters-clear"
-          title="Clear Filters"
-          type="button"
+        <span
+          class="css-1nqby2s"
         >
-          <span
-            class="css-1nqby2s"
-          >
-            Clear Filters
-          </span>
-        </button>
-      </div>
+          Clear Filters
+        </span>
+      </button>
     </div>
   </div>
 </div>
@@ -1368,7 +1364,6 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                   >
                     <input
                       aria-label="mention"
-                      checked=""
                       class="css-f3myyk"
                       name="mention"
                       tabindex="0"
@@ -1391,10 +1386,6 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                           width="12"
                           x="6"
                           y="6"
-                        />
-                        <path
-                          d="M9.707 11.293a1 1 0 1 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 1 0-1.414-1.414L11 12.586l-1.293-1.293z"
-                          fill="inherit"
                         />
                       </g>
                     </svg>
@@ -1424,10 +1415,10 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                     </svg>
                   </span>
                   <span
-                    class="css-g73hg0"
+                    class="css-1wkl091"
                   >
                     <span
-                      class="css-pvol9p"
+                      class="css-f9etm4"
                     >
                       0
                     </span>
@@ -1547,7 +1538,6 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                   >
                     <input
                       aria-label="direct"
-                      checked=""
                       class="css-f3myyk"
                       name="direct"
                       tabindex="0"
@@ -1570,10 +1560,6 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                           width="12"
                           x="6"
                           y="6"
-                        />
-                        <path
-                          d="M9.707 11.293a1 1 0 1 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 1 0-1.414-1.414L11 12.586l-1.293-1.293z"
-                          fill="inherit"
                         />
                       </g>
                     </svg>
@@ -1603,10 +1589,10 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                     </svg>
                   </span>
                   <span
-                    class="css-g73hg0"
+                    class="css-1wkl091"
                   >
                     <span
-                      class="css-pvol9p"
+                      class="css-f9etm4"
                     >
                       0
                     </span>
@@ -1715,7 +1701,6 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                   >
                     <input
                       aria-label="unread"
-                      checked=""
                       class="css-f3myyk"
                       name="unread"
                       tabindex="0"
@@ -1739,10 +1724,6 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                           x="6"
                           y="6"
                         />
-                        <path
-                          d="M9.707 11.293a1 1 0 1 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 1 0-1.414-1.414L11 12.586l-1.293-1.293z"
-                          fill="inherit"
-                        />
                       </g>
                     </svg>
                     <span
@@ -1752,10 +1733,10 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
                     </span>
                   </label>
                   <span
-                    class="css-g73hg0"
+                    class="css-1wkl091"
                   >
                     <span
-                      class="css-pvol9p"
+                      class="css-f9etm4"
                     >
                       0
                     </span>
@@ -2553,22 +2534,18 @@ exports[`renderer/routes/Filters.tsx filters product filters should filter by pr
     <div
       class="css-hugz22"
     >
-      <div
-        role="presentation"
+      <button
+        class="css-18yzeap"
+        data-testid="filters-clear"
+        title="Clear Filters"
+        type="button"
       >
-        <button
-          class="css-18yzeap"
-          data-testid="filters-clear"
-          title="Clear Filters"
-          type="button"
+        <span
+          class="css-1nqby2s"
         >
-          <span
-            class="css-1nqby2s"
-          >
-            Clear Filters
-          </span>
-        </button>
-      </div>
+          Clear Filters
+        </span>
+      </button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Since there is a reference between settings and defaultSettings, when you check any filter, it also mutates the defaultFilters array.
Using the spread operator fixes this.
Also, removed tooltip from Clear Filters, since the tooltip looks like an additional button