### PR TITLE
fix: show unread on tooltip only when toggle is on

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -94,7 +94,7 @@ export const Sidebar: FC = () => {
             </Tooltip>
 
             <Tooltip
-              content={`${notificationsLabel} unread notifications`}
+              content={`${notificationsLabel} ${settings.fetchOnlyUnreadNotifications ? 'unread ' : ''}notifications`}
               position="right"
             >
               <IconButton


### PR DESCRIPTION
Fixes #800 

When the Show Only Unread Notifications toggle is off, the tooltip on the bell icon shouldnt say "x unread notifications" since we show all notifications