### PR TITLE
fix: off by one error when max account notifications reached

### DIFF
--- a/src/renderer/components/notifications/AccountNotifications.test.tsx
+++ b/src/renderer/components/notifications/AccountNotifications.test.tsx
@@ -27,6 +27,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
       const props = {
         account: mockAtlassianCloudAccount,
         notifications: mockAtlassifyNotifications,
+        hasMoreNotifications: false,
         error: null,
       };
 
@@ -49,6 +50,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
       const props = {
         account: mockAtlassianCloudAccount,
         notifications: mockAtlassifyNotifications,
+        hasMoreNotifications: false,
         error: null,
       };
 
@@ -69,6 +71,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
       const props = {
         account: mockAtlassianCloudAccount,
         notifications: mockAtlassifyNotifications,
+        hasMoreNotifications: false,
         error: null,
       };
 
@@ -93,6 +96,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
       const props = {
         account: mockAtlassianCloudAccount,
         notifications: mockAtlassifyNotifications,
+        hasMoreNotifications: false,
         error: null,
       };
 
@@ -117,6 +121,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
       const props = {
         account: mockAtlassianCloudAccount,
         notifications: [],
+        hasMoreNotifications: false,
         error: null,
       };
 
@@ -137,6 +142,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
       const props = {
         account: mockAtlassianCloudAccount,
         notifications: [],
+        hasMoreNotifications: false,
         error: {
           title: 'Error title',
           descriptions: ['Error description'],
@@ -166,6 +172,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
     const props = {
       account: mockAtlassianCloudAccount,
       notifications: [],
+      hasMoreNotifications: false,
       error: null,
     };
 
@@ -193,6 +200,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
     const props = {
       account: mockAtlassianCloudAccount,
       notifications: [],
+      hasMoreNotifications: false,
       error: null,
     };
 
@@ -213,6 +221,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
     const props = {
       account: mockAtlassianCloudAccount,
       notifications: mockAtlassifyNotifications,
+      hasMoreNotifications: false,
       error: null,
     };
 
@@ -241,6 +250,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
     const props = {
       account: mockAtlassianCloudAccount,
       notifications: mockAtlassifyNotifications,
+      hasMoreNotifications: false,
       error: null,
     };
 
@@ -269,6 +279,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
     const props = {
       account: mockAtlassianCloudAccount,
       notifications: mockAtlassifyNotifications,
+      hasMoreNotifications: false,
       error: null,
     };
 

--- a/src/renderer/components/notifications/AccountNotifications.tsx
+++ b/src/renderer/components/notifications/AccountNotifications.tsx
@@ -41,13 +41,14 @@ import { ProductNotifications } from './ProductNotifications';
 interface IAccountNotifications {
   account: Account;
   notifications: AtlassifyNotification[];
+  hasMoreNotifications: boolean;
   error: AtlassifyError | null;
 }
 
 export const AccountNotifications: FC<IAccountNotifications> = (
   props: IAccountNotifications,
 ) => {
-  const { account, notifications } = props;
+  const { account, notifications, hasMoreNotifications } = props;
 
   const { markNotificationsRead, settings } = useContext(AppContext);
 
@@ -149,9 +150,11 @@ export const AccountNotifications: FC<IAccountNotifications> = (
             </Tooltip>{' '}
             <Badge
               appearance="primary"
-              max={Constants.MAX_NOTIFICATIONS_PER_ACCOUNT - 1}
+              max={Constants.MAX_NOTIFICATIONS_PER_ACCOUNT}
             >
-              {notifications.length}
+              {hasMoreNotifications
+                ? Constants.MAX_NOTIFICATIONS_PER_ACCOUNT + 1
+                : notifications.length}
             </Badge>
           </Inline>
 

--- a/src/renderer/routes/Notifications.tsx
+++ b/src/renderer/routes/Notifications.tsx
@@ -38,6 +38,7 @@ export const NotificationsRoute: FC = () => {
             key={accountNotifications.account.id}
             account={accountNotifications.account}
             notifications={accountNotifications.notifications}
+            hasMoreNotifications={accountNotifications.hasMoreNotifications}
             error={accountNotifications.error}
           />
         ))}


### PR DESCRIPTION
If account notifications hit the max limit of 999, the badge next to account name was showing `998+` instead of 999+