### PR TITLE
build: configure twemoji changelog to be upstream fork

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,11 @@
       "extends": ["packages:atlaskit"],
       "sourceUrl": "https://bitbucket.org/atlassian/atlassian-frontend-mirror",
       "sourceDirectory": "design-system/{{ lookup (split packageName '/') 1 }}"
+    },
+    {
+      "description": "Fetch changelog details for twemoji packages",
+      "matchPackageNames": ["@discordapp/twemoji", "@twemoji/api"],
+      "sourceUrl": "https://github.com/jdjdecked/twemoji"
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -39,7 +39,7 @@
     },
     {
       "description": "Fetch changelog details for twemoji packages",
-      "matchPackageNames": ["@discordapp/twemoji", "@twemoji/api"],
+      "matchPackageNames": ["@discordapp/twemoji"],
       "sourceUrl": "https://github.com/jdjdecked/twemoji"
     }
   ],


### PR DESCRIPTION
Fetch changelog notes for https://github.com/discord/twemoji from https://github.com/jdecked/twemoji