### PR TITLE
refactor: remove temp package

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@atlaskit/radio": "8.2.0",
     "@atlaskit/select": "21.2.4",
     "@atlaskit/spinner": "19.0.1",
-    "@atlaskit/temp-nav-app-icons": "0.10.0",
     "@atlaskit/textfield": "8.0.9",
     "@atlaskit/toggle": "15.1.1",
     "@atlaskit/tokens": "6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,9 +90,6 @@ importers:
       '@atlaskit/spinner':
         specifier: 19.0.1
         version: 19.0.1(@types/react@18.3.23)(react@18.3.1)
-      '@atlaskit/temp-nav-app-icons':
-        specifier: 0.10.0
-        version: 0.10.0(@types/react@18.3.23)(react@18.3.1)
       '@atlaskit/textfield':
         specifier: 8.0.9
         version: 8.0.9(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
Closes #1133 

No longer require the temporary package used to transition to the new Atlassian Design System icons