### PR TITLE
feat: cross-platform auto updating

### DIFF
--- a/config/webpack.config.renderer.base.ts
+++ b/config/webpack.config.renderer.base.ts
@@ -7,7 +7,7 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import type webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
-import { Constants } from '../src/renderer/utils/constants';
+import { Constants } from '../src/renderer/constants';
 import { Errors } from '../src/renderer/utils/errors';
 import baseConfig from './webpack.config.common';
 import webpackPaths from './webpack.paths';

--- a/package.json
+++ b/package.json
@@ -66,8 +66,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-i18next": "15.7.2",
-    "react-router-dom": "7.8.2",
-    "update-electron-app": "3.1.1"
+    "react-router-dom": "7.8.2"
   },
   "devDependencies": {
     "@0no-co/graphqlsp": "1.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       react-router-dom:
         specifier: 7.8.2
         version: 7.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      update-electron-app:
-        specifier: 3.1.1
-        version: 3.1.1
     devDependencies:
       '@0no-co/graphqlsp':
         specifier: 1.15.0
@@ -3206,9 +3203,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  github-url-to-object@4.0.6:
-    resolution: {integrity: sha512-NaqbYHMUAlPcmWFdrAB7bcxrNIiiJWJe8s/2+iOc9vlcHlwHqSGrPk+Yi3nu6ebTwgsZEa7igz+NH2vEq3gYwQ==}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -3579,9 +3573,6 @@ packages:
   is-url-superb@4.0.0:
     resolution: {integrity: sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==}
     engines: {node: '>=10'}
-
-  is-url@1.2.4:
-    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -5698,9 +5689,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  update-electron-app@3.1.1:
-    resolution: {integrity: sha512-7duRr6sYn014tifhKgT/5i8N+6xLzmJVJ8hVtNrHXlIDNP6QbRe6VxZ1hSi2UH5oJPzhor/PH7yKU9em5xjRzQ==}
 
   upper-case-first@2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
@@ -10099,10 +10087,6 @@ snapshots:
 
   get-stream@6.0.1: {}
 
-  github-url-to-object@4.0.6:
-    dependencies:
-      is-url: 1.2.4
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -10512,8 +10496,6 @@ snapshots:
       tslib: 2.8.1
 
   is-url-superb@4.0.0: {}
-
-  is-url@1.2.4: {}
 
   is-windows@1.0.2: {}
 
@@ -12723,11 +12705,6 @@ snapshots:
       browserslist: 4.25.1
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  update-electron-app@3.1.1:
-    dependencies:
-      github-url-to-object: 4.0.6
-      ms: 2.1.3
 
   upper-case-first@2.0.2:
     dependencies:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,7 +69,7 @@ const contextMenu = menuBuilder.buildMenu();
 
 // Initialize updater for all supported platforms (macOS, Windows, Linux)
 const updater = new Updater(mb, menuBuilder);
-updater.initialize();
+void updater.initialize();
 
 let shouldUseAlternateIdleIcon = false;
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,7 +18,6 @@ import {
   type IKeyboardShortcut,
   type IOpenExternal,
 } from '../shared/events';
-import { isMacOS, isWindows } from '../shared/platform';
 import { Theme } from '../shared/theme';
 
 import { handleMainEvent, onMainEvent, sendRendererEvent } from './events';
@@ -68,14 +67,9 @@ const mb = menubar({
 const menuBuilder = new MenuBuilder(mb);
 const contextMenu = menuBuilder.buildMenu();
 
-/**
- * Electron Auto Updater only supports macOS and Windows
- * https://github.com/electron/update-electron-app
- */
-if (isMacOS() || isWindows()) {
-  const updater = new Updater(mb, menuBuilder);
-  updater.initialize();
-}
+// Initialize updater for all supported platforms (macOS, Windows, Linux)
+const updater = new Updater(mb, menuBuilder);
+updater.initialize();
 
 let shouldUseAlternateIdleIcon = false;
 

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -18,83 +18,97 @@ describe('main/menu.ts', () => {
     menuBuilder = new MenuBuilder(menubar);
   });
 
-  it('should create menu items correctly', () => {
-    expect(MenuItem).toHaveBeenCalledWith({
-      label: 'Check for updates',
-      enabled: true,
-      click: expect.any(Function),
-    });
-
-    expect(MenuItem).toHaveBeenCalledWith({
-      label: 'No updates available',
-      enabled: false,
-      visible: false,
-    });
-
-    expect(MenuItem).toHaveBeenCalledWith({
-      label: 'An update is available',
-      enabled: false,
-      visible: false,
-    });
-
-    expect(MenuItem).toHaveBeenCalledWith({
-      label: 'Restart to install update',
-      enabled: true,
-      visible: false,
-      click: expect.any(Function),
-    });
-  });
-
   it('should build menu correctly', () => {
     menuBuilder.buildMenu();
     expect(Menu.buildFromTemplate).toHaveBeenCalledWith(expect.any(Array));
   });
 
-  it('should enable check for updates menu item', () => {
-    menuBuilder.setCheckForUpdatesMenuEnabled(true);
-    // biome-ignore lint/complexity/useLiteralKeys: This is a test
-    expect(menuBuilder['checkForUpdatesMenuItem'].enabled).toBe(true);
+  describe('checkForUpdatesMenuItem', () => {
+    it('default menu configuration', () => {
+      expect(MenuItem).toHaveBeenCalledWith({
+        label: 'Check for updates',
+        enabled: true,
+        click: expect.any(Function),
+      });
+    });
+
+    it('should enable menu item', () => {
+      menuBuilder.setCheckForUpdatesMenuEnabled(true);
+      // biome-ignore lint/complexity/useLiteralKeys: This is a test
+      expect(menuBuilder['checkForUpdatesMenuItem'].enabled).toBe(true);
+    });
+
+    it('should disable menu item', () => {
+      menuBuilder.setCheckForUpdatesMenuEnabled(false);
+      // biome-ignore lint/complexity/useLiteralKeys: This is a test
+      expect(menuBuilder['checkForUpdatesMenuItem'].enabled).toBe(false);
+    });
   });
 
-  it('should disable check for updates menu item', () => {
-    menuBuilder.setCheckForUpdatesMenuEnabled(false);
-    // biome-ignore lint/complexity/useLiteralKeys: This is a test
-    expect(menuBuilder['checkForUpdatesMenuItem'].enabled).toBe(false);
+  describe('noUpdateAvailableMenuItem', () => {
+    it('default menu configuration', () => {
+      expect(MenuItem).toHaveBeenCalledWith({
+        label: 'No updates available',
+        enabled: false,
+        visible: false,
+      });
+    });
+
+    it('should show menu item', () => {
+      menuBuilder.setNoUpdateAvailableMenuVisibility(true);
+      // biome-ignore lint/complexity/useLiteralKeys: This is a test
+      expect(menuBuilder['noUpdateAvailableMenuItem'].visible).toBe(true);
+    });
+
+    it('should hide  menu item', () => {
+      menuBuilder.setNoUpdateAvailableMenuVisibility(false);
+      // biome-ignore lint/complexity/useLiteralKeys: This is a test
+      expect(menuBuilder['noUpdateAvailableMenuItem'].visible).toBe(false);
+    });
   });
 
-  it('should show no update available menu item', () => {
-    menuBuilder.setNoUpdateAvailableMenuVisibility(true);
-    // biome-ignore lint/complexity/useLiteralKeys: This is a test
-    expect(menuBuilder['noUpdateAvailableMenuItem'].visible).toBe(true);
+  describe('updateAvailableMenuItem', () => {
+    it('default menu configuration', () => {
+      expect(MenuItem).toHaveBeenCalledWith({
+        label: 'An update is available',
+        enabled: false,
+        visible: false,
+      });
+    });
+
+    it('should show menu item', () => {
+      menuBuilder.setUpdateAvailableMenuVisibility(true);
+      // biome-ignore lint/complexity/useLiteralKeys: This is a test
+      expect(menuBuilder['updateAvailableMenuItem'].visible).toBe(true);
+    });
+
+    it('should hide menu item', () => {
+      menuBuilder.setUpdateAvailableMenuVisibility(false);
+      // biome-ignore lint/complexity/useLiteralKeys: This is a test
+      expect(menuBuilder['updateAvailableMenuItem'].visible).toBe(false);
+    });
   });
 
-  it('should hide no update available  menu item', () => {
-    menuBuilder.setNoUpdateAvailableMenuVisibility(false);
-    // biome-ignore lint/complexity/useLiteralKeys: This is a test
-    expect(menuBuilder['noUpdateAvailableMenuItem'].visible).toBe(false);
-  });
+  describe('updateReadyForInstallMenuItem', () => {
+    it('default menu configuration', () => {
+      expect(MenuItem).toHaveBeenCalledWith({
+        label: 'Restart to install update',
+        enabled: true,
+        visible: false,
+        click: expect.any(Function),
+      });
+    });
 
-  it('should show update available menu item', () => {
-    menuBuilder.setUpdateAvailableMenuVisibility(true);
-    // biome-ignore lint/complexity/useLiteralKeys: This is a test
-    expect(menuBuilder['updateAvailableMenuItem'].visible).toBe(true);
-  });
+    it('should show menu item', () => {
+      menuBuilder.setUpdateReadyForInstallMenuVisibility(true);
+      // biome-ignore lint/complexity/useLiteralKeys: This is a test
+      expect(menuBuilder['updateReadyForInstallMenuItem'].visible).toBe(true);
+    });
 
-  it('should hide update available menu item', () => {
-    menuBuilder.setUpdateAvailableMenuVisibility(false);
-    // biome-ignore lint/complexity/useLiteralKeys: This is a test
-    expect(menuBuilder['updateAvailableMenuItem'].visible).toBe(false);
-  });
-
-  it('should show update ready for install menu item', () => {
-    menuBuilder.setUpdateReadyForInstallMenuVisibility(true);
-    // biome-ignore lint/complexity/useLiteralKeys: This is a test
-    expect(menuBuilder['updateReadyForInstallMenuItem'].visible).toBe(true);
-  });
-
-  it('should show update ready for install menu item', () => {
-    menuBuilder.setUpdateReadyForInstallMenuVisibility(false);
-    // biome-ignore lint/complexity/useLiteralKeys: This is a test
-    expect(menuBuilder['updateReadyForInstallMenuItem'].visible).toBe(false);
+    it('should hide menu item', () => {
+      menuBuilder.setUpdateReadyForInstallMenuVisibility(false);
+      // biome-ignore lint/complexity/useLiteralKeys: This is a test
+      expect(menuBuilder['updateReadyForInstallMenuItem'].visible).toBe(false);
+    });
   });
 });

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -1,26 +1,76 @@
-import { Menu, MenuItem } from 'electron';
+import { Menu, MenuItem, shell } from 'electron';
+import { autoUpdater } from 'electron-updater';
 import type { Menubar } from 'menubar';
 
-import MenuBuilder from './menu';
+import { APPLICATION } from '../shared/constants';
 
-jest.mock('electron', () => ({
-  Menu: {
-    buildFromTemplate: jest.fn(),
+import MenuBuilder from './menu';
+import { openLogsDirectory, resetApp, takeScreenshot } from './utils';
+
+jest.mock('electron', () => {
+  const MenuItem = jest
+    .fn()
+    .mockImplementation((opts: Record<string, unknown>) => opts);
+  return {
+    Menu: {
+      buildFromTemplate: jest.fn(),
+    },
+    MenuItem,
+    shell: { openExternal: jest.fn() },
+  };
+});
+
+jest.mock('electron-updater', () => ({
+  autoUpdater: {
+    checkForUpdatesAndNotify: jest.fn(),
+    quitAndInstall: jest.fn(),
   },
-  MenuItem: jest.fn(),
+}));
+
+jest.mock('./utils', () => ({
+  takeScreenshot: jest.fn(),
+  openLogsDirectory: jest.fn(),
+  resetApp: jest.fn(),
 }));
 
 describe('main/menu.ts', () => {
   let menubar: Menubar;
   let menuBuilder: MenuBuilder;
 
-  beforeEach(() => {
-    menuBuilder = new MenuBuilder(menubar);
-  });
+  /** Helper: find MenuItem config captured via MenuItem mock by label */
+  const getMenuItemConfigByLabel = (label: string) =>
+    (MenuItem as unknown as jest.Mock).mock.calls.find(
+      ([arg]) => (arg as { label?: string }).label === label,
+    )?.[0] as
+      | {
+          label?: string;
+          enabled?: boolean;
+          visible?: boolean;
+          click?: () => void;
+        }
+      | undefined;
 
-  it('should build menu correctly', () => {
+  /** Lightweight type describing the (subset) of fields we inspect on template items */
+  type TemplateItem = {
+    label?: string;
+    role?: string;
+    accelerator?: string;
+    submenu?: TemplateItem[];
+    click?: () => void;
+  };
+
+  /** Helper: build menu & return template (first arg passed to buildFromTemplate) */
+  const buildAndGetTemplate = () => {
     menuBuilder.buildMenu();
-    expect(Menu.buildFromTemplate).toHaveBeenCalledWith(expect.any(Array));
+    return (Menu.buildFromTemplate as jest.Mock).mock.calls.slice(
+      -1,
+    )[0][0] as TemplateItem[];
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    menubar = { app: { quit: jest.fn() } } as unknown as Menubar;
+    menuBuilder = new MenuBuilder(menubar);
   });
 
   describe('checkForUpdatesMenuItem', () => {
@@ -109,6 +159,111 @@ describe('main/menu.ts', () => {
       menuBuilder.setUpdateReadyForInstallMenuVisibility(false);
       // biome-ignore lint/complexity/useLiteralKeys: This is a test
       expect(menuBuilder['updateReadyForInstallMenuItem'].visible).toBe(false);
+    });
+  });
+
+  describe('click handlers', () => {
+    it('invokes autoUpdater.checkForUpdatesAndNotify when clicking "Check for updates"', () => {
+      const cfg = getMenuItemConfigByLabel('Check for updates');
+      expect(cfg).toBeDefined();
+      cfg.click();
+      expect(autoUpdater.checkForUpdatesAndNotify).toHaveBeenCalled();
+    });
+
+    it('invokes autoUpdater.quitAndInstall when clicking "Restart to install update"', () => {
+      const cfg = getMenuItemConfigByLabel('Restart to install update');
+      expect(cfg).toBeDefined();
+      cfg.click();
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalled();
+    });
+
+    it('developer submenu click actions execute expected functions', () => {
+      const template = buildAndGetTemplate();
+      const devEntry = template.find(
+        (item) => item?.label === 'Developer',
+      ) as TemplateItem;
+      expect(devEntry).toBeDefined();
+      const submenu = devEntry.submenu;
+      const clickByLabel = (label: string) =>
+        submenu.find((i) => i.label === label)?.click?.();
+
+      clickByLabel('Take Screenshot');
+      expect(takeScreenshot).toHaveBeenCalledWith(menubar);
+
+      clickByLabel('View Application Logs');
+      expect(openLogsDirectory).toHaveBeenCalled();
+
+      clickByLabel('Visit Repository');
+      expect(shell.openExternal).toHaveBeenCalledWith(
+        `https://github.com/${APPLICATION.REPO_SLUG}`,
+      );
+
+      clickByLabel(`Reset ${APPLICATION.NAME}`);
+      expect(resetApp).toHaveBeenCalledWith(menubar);
+    });
+
+    it('website menu item opens external URL', () => {
+      const template = buildAndGetTemplate();
+      const item = template.find((i) => i.label === 'Visit Website');
+      item.click();
+      expect(shell.openExternal).toHaveBeenCalledWith(APPLICATION.WEBSITE);
+    });
+
+    it('quit menu item quits the app', () => {
+      const template = buildAndGetTemplate();
+      const item = template.find((i) => i.label === `Quit ${APPLICATION.NAME}`);
+      item.click();
+      expect(menubar.app.quit).toHaveBeenCalled();
+    });
+
+    it('developer submenu includes expected static accelerators', () => {
+      const template = buildAndGetTemplate();
+      const devEntry = template.find(
+        (item) => item?.label === 'Developer',
+      ) as TemplateItem;
+      const reloadItem = devEntry.submenu.find((i) => i.role === 'reload');
+      expect(reloadItem?.accelerator).toBe('CommandOrControl+R');
+    });
+  });
+
+  describe('platform-specific accelerators', () => {
+    // Use isolateModules so we can alter the isMacOS return value before importing MenuBuilder
+    const buildTemplateWithPlatform = (isMac: boolean) => {
+      jest.isolateModules(() => {
+        jest.doMock('../shared/platform', () => ({ isMacOS: () => isMac }));
+        // re-mock electron for isolated module context (shared mock factory already defined globally)
+        // Clear prior captured calls
+        (Menu.buildFromTemplate as jest.Mock).mockClear();
+        const MB = require('./menu').default as typeof MenuBuilder;
+        const mb = new MB({ app: { quit: jest.fn() } } as unknown as Menubar);
+        mb.buildMenu();
+      });
+      // Return the newest template captured
+      return (Menu.buildFromTemplate as jest.Mock).mock.calls.slice(
+        -1,
+      )[0][0] as TemplateItem[];
+    };
+
+    it('uses mac accelerator for toggleDevTools when on macOS', () => {
+      const template = buildTemplateWithPlatform(true);
+      const devEntry = template.find(
+        (i) => i?.label === 'Developer',
+      ) as TemplateItem;
+      const toggleItem = devEntry.submenu.find(
+        (i) => i.role === 'toggleDevTools',
+      );
+      expect(toggleItem?.accelerator).toBe('Alt+Cmd+I');
+    });
+
+    it('uses non-mac accelerator for toggleDevTools otherwise', () => {
+      const template = buildTemplateWithPlatform(false);
+      const devEntry = template.find(
+        (i) => i?.label === 'Developer',
+      ) as TemplateItem;
+      const toggleItem = devEntry.submenu.find(
+        (i) => i.role === 'toggleDevTools',
+      );
+      expect(toggleItem?.accelerator).toBe('Ctrl+Shift+I');
     });
   });
 });

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -3,7 +3,7 @@ import { autoUpdater } from 'electron-updater';
 import type { Menubar } from 'menubar';
 
 import { APPLICATION } from '../shared/constants';
-import { isMacOS, isWindows } from '../shared/platform';
+import { isMacOS } from '../shared/platform';
 
 import { openLogsDirectory, resetApp, takeScreenshot } from './utils';
 
@@ -22,11 +22,7 @@ export default class MenuBuilder {
       label: 'Check for updates',
       enabled: true,
       click: () => {
-        if (isMacOS() || isWindows()) {
-          autoUpdater.checkForUpdatesAndNotify();
-        } else {
-          shell.openExternal(APPLICATION.WEBSITE);
-        }
+        autoUpdater.checkForUpdatesAndNotify();
       },
     });
 
@@ -80,6 +76,11 @@ export default class MenuBuilder {
             click: () => openLogsDirectory(),
           },
           {
+            label: 'Visit Repository',
+            click: () =>
+              shell.openExternal(`https://github.com/${APPLICATION.REPO_SLUG}`),
+          },
+          {
             label: `Reset ${APPLICATION.NAME}`,
             click: () => {
               resetApp(this.menubar);
@@ -88,6 +89,10 @@ export default class MenuBuilder {
         ],
       },
       { type: 'separator' },
+      {
+        label: 'Visit Website',
+        click: () => shell.openExternal(APPLICATION.WEBSITE),
+      },
       {
         label: `Quit ${APPLICATION.NAME}`,
         accelerator: 'CommandOrControl+Q',

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -77,8 +77,9 @@ export default class MenuBuilder {
           },
           {
             label: 'Visit Repository',
-            click: () =>
-              shell.openExternal(`https://github.com/${APPLICATION.REPO_SLUG}`),
+            click: () => {
+              shell.openExternal(`https://github.com/${APPLICATION.REPO_SLUG}`);
+            },
           },
           {
             label: `Reset ${APPLICATION.NAME}`,
@@ -91,7 +92,9 @@ export default class MenuBuilder {
       { type: 'separator' },
       {
         label: 'Visit Website',
-        click: () => shell.openExternal(APPLICATION.WEBSITE),
+        click: () => {
+          shell.openExternal(APPLICATION.WEBSITE);
+        },
       },
       {
         label: `Quit ${APPLICATION.NAME}`,

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1,0 +1,222 @@
+import { dialog } from 'electron';
+import type { Menubar } from 'menubar';
+
+import { APPLICATION } from '../shared/constants';
+import { logError, logInfo } from '../shared/logger';
+
+jest.mock('../shared/logger', () => ({
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+}));
+
+import MenuBuilder from './menu';
+import Updater from './updater';
+
+// Mock electron-updater with an EventEmitter-like interface
+type UpdateDownloadedEvent = { releaseName: string };
+type ListenerArgs = UpdateDownloadedEvent | object | undefined;
+type Listener = (arg: ListenerArgs) => void;
+type ListenerMap = Record<string, Listener[]>;
+const listeners: ListenerMap = {};
+
+jest.mock('electron-updater', () => ({
+  autoUpdater: {
+    on: jest.fn((event: string, cb: Listener) => {
+      if (!listeners[event]) listeners[event] = [];
+      listeners[event].push(cb);
+      return this;
+    }),
+    checkForUpdatesAndNotify: jest.fn().mockResolvedValue(undefined),
+    quitAndInstall: jest.fn(),
+  },
+}));
+
+// Mock electron (dialog + basic Menu API used by MenuBuilder constructor)
+jest.mock('electron', () => {
+  const MenuItem = jest.fn().mockImplementation((opts: unknown) => opts);
+  return {
+    dialog: { showMessageBox: jest.fn() },
+    MenuItem,
+    Menu: { buildFromTemplate: jest.fn() },
+    shell: { openExternal: jest.fn() },
+  };
+});
+
+// Utility to emit mocked autoUpdater events
+const emit = (event: string, arg?: ListenerArgs) => {
+  (listeners[event] || []).forEach((cb) => {
+    cb(arg);
+  });
+};
+
+// Re-import autoUpdater after mocking
+import { autoUpdater } from 'electron-updater';
+
+describe('main/updater.ts', () => {
+  let menubar: Menubar;
+  class TestMenuBuilder extends MenuBuilder {
+    public setCheckForUpdatesMenuEnabled = jest.fn();
+    public setNoUpdateAvailableMenuVisibility = jest.fn();
+    public setUpdateAvailableMenuVisibility = jest.fn();
+    public setUpdateReadyForInstallMenuVisibility = jest.fn();
+    constructor(mb: Menubar) {
+      super(mb);
+    }
+  }
+  let menuBuilder: TestMenuBuilder;
+  let updater: Updater;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const k of Object.keys(listeners)) delete listeners[k];
+
+    menubar = {
+      app: { isPackaged: true },
+      tray: { setToolTip: jest.fn() },
+    } as unknown as Menubar;
+
+    menuBuilder = new TestMenuBuilder(menubar);
+    updater = new Updater(menubar, menuBuilder);
+  });
+
+  describe('update available dialog', () => {
+    it('shows dialog with expected message and does NOT install when user chooses Later', async () => {
+      (dialog.showMessageBox as jest.Mock).mockResolvedValue({ response: 1 }); // "Later"
+
+      await updater.initialize();
+
+      // Simulate update downloaded event
+      const releaseName = 'v1.2.3';
+      emit('update-downloaded', { releaseName });
+
+      expect(dialog.showMessageBox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            `${APPLICATION.NAME} ${releaseName} has been downloaded`,
+          ),
+          buttons: ['Restart', 'Later'],
+        }),
+      );
+      expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+      // Menu state updates invoked
+      expect(menuBuilder.setUpdateAvailableMenuVisibility).toHaveBeenCalledWith(
+        false,
+      );
+      expect(
+        menuBuilder.setUpdateReadyForInstallMenuVisibility,
+      ).toHaveBeenCalledWith(true);
+    });
+
+    it('invokes quitAndInstall when user clicks Restart', async () => {
+      (dialog.showMessageBox as jest.Mock).mockResolvedValue({ response: 0 }); // "Restart"
+
+      await updater.initialize();
+      emit('update-downloaded', { releaseName: 'v9.9.9' });
+      // Allow then() of showMessageBox promise to resolve
+      await Promise.resolve();
+
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalled();
+    });
+  });
+
+  describe('update event handlers & scheduling', () => {
+    it('skips when app is not packaged', async () => {
+      Object.defineProperty(menubar.app, 'isPackaged', { value: false });
+      await updater.initialize();
+      expect(logInfo).toHaveBeenCalledWith(
+        'updater',
+        'Skipping updater since app is in development mode',
+      );
+      expect(autoUpdater.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it('handles checking-for-update', async () => {
+      await updater.initialize();
+      emit('checking-for-update');
+      expect(menuBuilder.setCheckForUpdatesMenuEnabled).toHaveBeenCalledWith(
+        false,
+      );
+      expect(
+        menuBuilder.setNoUpdateAvailableMenuVisibility,
+      ).toHaveBeenCalledWith(false);
+    });
+
+    it('handles update-available', async () => {
+      await updater.initialize();
+      emit('update-available');
+      expect(menuBuilder.setUpdateAvailableMenuVisibility).toHaveBeenCalledWith(
+        true,
+      );
+      expect(menubar.tray.setToolTip).toHaveBeenCalledWith(
+        expect.stringContaining('A new update is available'),
+      );
+    });
+
+    it('handles download-progress', async () => {
+      await updater.initialize();
+      emit('download-progress', { percent: 12.3456 });
+      expect(menubar.tray.setToolTip).toHaveBeenCalledWith(
+        expect.stringContaining('12.35%'),
+      );
+    });
+
+    it('handles update-not-available', async () => {
+      await updater.initialize();
+      emit('update-not-available');
+      expect(menuBuilder.setCheckForUpdatesMenuEnabled).toHaveBeenCalledWith(
+        true,
+      );
+      expect(
+        menuBuilder.setNoUpdateAvailableMenuVisibility,
+      ).toHaveBeenCalledWith(true);
+      expect(menuBuilder.setUpdateAvailableMenuVisibility).toHaveBeenCalledWith(
+        false,
+      );
+      expect(
+        menuBuilder.setUpdateReadyForInstallMenuVisibility,
+      ).toHaveBeenCalledWith(false);
+    });
+
+    it('handles update-cancelled (reset state)', async () => {
+      await updater.initialize();
+      emit('update-cancelled');
+      expect(menubar.tray.setToolTip).toHaveBeenCalledWith(APPLICATION.NAME);
+      expect(menuBuilder.setCheckForUpdatesMenuEnabled).toHaveBeenCalledWith(
+        true,
+      );
+    });
+
+    it('handles error (reset + logError)', async () => {
+      await updater.initialize();
+      const err = new Error('failure');
+      emit('error', err);
+      expect(logError).toHaveBeenCalledWith(
+        'auto updater',
+        'Error checking for update',
+        err,
+      );
+      expect(menubar.tray.setToolTip).toHaveBeenCalledWith(APPLICATION.NAME);
+    });
+
+    it('schedules periodic checks after initial', async () => {
+      const originalSetInterval = global.setInterval;
+      const setIntervalSpy = jest
+        .spyOn(global, 'setInterval')
+        .mockImplementation(((fn: () => void) => {
+          fn();
+          return 0 as unknown as NodeJS.Timer;
+        }) as unknown as typeof setInterval);
+      try {
+        await updater.initialize();
+        expect(autoUpdater.checkForUpdatesAndNotify).toHaveBeenCalledTimes(2);
+        expect(setIntervalSpy).toHaveBeenCalledWith(
+          expect.any(Function),
+          APPLICATION.UPDATE_CHECK_INTERVAL_MS,
+        );
+      } finally {
+        setIntervalSpy.mockRestore();
+        global.setInterval = originalSetInterval;
+      }
+    });
+  });
+});

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -24,7 +24,7 @@ export default class Updater {
     this.menuBuilder = menuBuilder;
   }
 
-  initialize(): void {
+  async initialize(): Promise<void> {
     if (!this.menubar.app.isPackaged) {
       logInfo('updater', 'Skipping updater since app is in development mode');
       return;
@@ -83,17 +83,17 @@ export default class Updater {
       this.resetState();
     });
 
-    // Kick off an immediate check (packaged apps only); ignore errors here.
+    // Kick off an immediate check (packaged apps only)
     try {
-      autoUpdater.checkForUpdatesAndNotify();
+      await autoUpdater.checkForUpdatesAndNotify();
     } catch (e) {
       logError('auto updater', 'Initial check failed', e as Error);
     }
 
     // Schedule periodic checks
-    setInterval(() => {
+    setInterval(async () => {
       try {
-        autoUpdater.checkForUpdatesAndNotify();
+        await autoUpdater.checkForUpdatesAndNotify();
       } catch (e) {
         logError('auto updater', 'Scheduled check failed', e as Error);
       }

--- a/src/renderer/components/AllRead.tsx
+++ b/src/renderer/components/AllRead.tsx
@@ -1,8 +1,8 @@
 import { type FC, useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { Constants } from '../constants';
 import { AppContext } from '../context/App';
-import { Constants } from '../utils/constants';
 import { hasActiveFilters } from '../utils/notifications/filters';
 import { EmojiSplash } from './layout/EmojiSplash';
 

--- a/src/renderer/components/notifications/AccountNotifications.tsx
+++ b/src/renderer/components/notifications/AccountNotifications.tsx
@@ -25,13 +25,13 @@ import Modal, {
 import { Box, Flex, Grid, Inline, Stack, xcss } from '@atlaskit/primitives';
 import Tooltip from '@atlaskit/tooltip';
 
+import { Constants } from '../../constants';
 import { AppContext } from '../../context/App';
 import type {
   Account,
   AtlassifyError,
   AtlassifyNotification,
 } from '../../types';
-import { Constants } from '../../utils/constants';
 import { getChevronDetails } from '../../utils/helpers';
 import { openAccountProfile, openMyPullRequests } from '../../utils/links';
 import { isLightMode } from '../../utils/theme';

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -1,15 +1,13 @@
 export const Constants = {
-  REPO_SLUG: 'setchy/atlassify',
-
   STORAGE_KEY: 'atlassify-storage',
 
   LANGUAGE_STORAGE_KEY: 'atlassify-language',
 
   ALL_READ_EMOJIS: ['🎉', '🎊', '🥳', '👏', '🙌', '😎', '🏖️', '🚀', '✨', '🏆'],
 
-  FETCH_NOTIFICATIONS_INTERVAL: 60000,
+  FETCH_NOTIFICATIONS_INTERVAL_MS: 60 * 1000, // 1 minute
 
-  REFRESH_ACCOUNTS_INTERVAL: 3600000,
+  REFRESH_ACCOUNTS_INTERVAL_MS: 60 * 60 * 1000, // 1 hour
 
   MAX_NOTIFICATIONS_PER_ACCOUNT: 999,
 

--- a/src/renderer/context/App.test.tsx
+++ b/src/renderer/context/App.test.tsx
@@ -3,10 +3,10 @@ import { useContext } from 'react';
 
 import { mockSingleAtlassifyNotification } from '../__mocks__/notifications-mocks';
 import { mockAuth, mockSettings } from '../__mocks__/state-mocks';
+import { Constants } from '../constants';
 import { useNotifications } from '../hooks/useNotifications';
 import type { AuthState, SettingsState } from '../types';
 import * as comms from '../utils/comms';
-import { Constants } from '../utils/constants';
 import * as notifications from '../utils/notifications/notifications';
 import * as storage from '../utils/storage';
 import { AppContext, AppProvider } from './App';
@@ -76,17 +76,17 @@ describe('renderer/context/App.tsx', () => {
       );
 
       act(() => {
-        jest.advanceTimersByTime(Constants.FETCH_NOTIFICATIONS_INTERVAL);
+        jest.advanceTimersByTime(Constants.FETCH_NOTIFICATIONS_INTERVAL_MS);
       });
       expect(fetchNotificationsMock).toHaveBeenCalledTimes(2);
 
       act(() => {
-        jest.advanceTimersByTime(Constants.FETCH_NOTIFICATIONS_INTERVAL);
+        jest.advanceTimersByTime(Constants.FETCH_NOTIFICATIONS_INTERVAL_MS);
       });
       expect(fetchNotificationsMock).toHaveBeenCalledTimes(3);
 
       act(() => {
-        jest.advanceTimersByTime(Constants.FETCH_NOTIFICATIONS_INTERVAL);
+        jest.advanceTimersByTime(Constants.FETCH_NOTIFICATIONS_INTERVAL_MS);
       });
       expect(fetchNotificationsMock).toHaveBeenCalledTimes(4);
     });

--- a/src/renderer/context/App.tsx
+++ b/src/renderer/context/App.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from 'react';
 
+import { Constants } from '../constants';
 import { useInterval } from '../hooks/useInterval';
 import { useNotifications } from '../hooks/useNotifications';
 import type {
@@ -34,7 +35,6 @@ import {
   setKeyboardShortcut,
   updateTrayTitle,
 } from '../utils/comms';
-import { Constants } from '../utils/constants';
 import {
   getNotificationCount,
   hasMoreNotifications,
@@ -115,13 +115,13 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   useInterval(() => {
     fetchNotifications({ auth, settings });
-  }, Constants.FETCH_NOTIFICATIONS_INTERVAL);
+  }, Constants.FETCH_NOTIFICATIONS_INTERVAL_MS);
 
   useInterval(() => {
     for (const account of auth.accounts) {
       refreshAccount(account);
     }
-  }, Constants.REFRESH_ACCOUNTS_INTERVAL);
+  }, Constants.REFRESH_ACCOUNTS_INTERVAL_MS);
 
   useEffect(() => {
     const count = getNotificationCount(notifications);

--- a/src/renderer/i18n/index.ts
+++ b/src/renderer/i18n/index.ts
@@ -3,7 +3,7 @@ import { initReactI18next } from 'react-i18next';
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-import { Constants } from '../utils/constants';
+import { Constants } from '../constants';
 // Locales
 import deTranslation from './locales/de.json';
 import enTranslation from './locales/en.json';

--- a/src/renderer/utils/api/client.test.ts
+++ b/src/renderer/utils/api/client.test.ts
@@ -5,8 +5,8 @@ import {
   mockAtlassianCloudAccount,
   mockSettings,
 } from '../../__mocks__/state-mocks';
+import { Constants } from '../../constants';
 import type { CloudID, Hostname, JiraProjectKey } from '../../types';
-import { Constants } from '../constants';
 import {
   checkIfCredentialsAreValid,
   getAuthenticatedUser,

--- a/src/renderer/utils/api/client.ts
+++ b/src/renderer/utils/api/client.ts
@@ -1,3 +1,4 @@
+import { Constants } from '../../constants';
 import type {
   Account,
   CloudID,
@@ -7,7 +8,6 @@ import type {
   Token,
   Username,
 } from '../../types';
-import { Constants } from '../constants';
 import { graphql } from './graphql/generated/gql';
 import {
   InfluentsNotificationReadState,

--- a/src/renderer/utils/helpers.ts
+++ b/src/renderer/utils/helpers.ts
@@ -5,9 +5,9 @@ import type { AlignBlock } from '@atlaskit/primitives/dist/types/components/type
 
 import { formatDistanceToNowStrict, isValid, parseISO } from 'date-fns';
 
+import { Constants } from '../constants';
 import i18n from '../i18n';
 import type { AtlassifyNotification, Chevron } from '../types';
-import { Constants } from './constants';
 
 export function formatProperCase(text: string) {
   return text.replace(/\w+/g, (word) => {

--- a/src/renderer/utils/links.ts
+++ b/src/renderer/utils/links.ts
@@ -1,6 +1,7 @@
+import { APPLICATION } from '../../shared/constants';
+
 import type { Account, AtlassifyNotification, Link } from '../types';
 import { openExternalLink } from './comms';
-import { Constants } from './constants';
 
 export const URLs = {
   ATLASSIAN: {
@@ -21,7 +22,7 @@ export const URLs = {
 
 export function openAtlassifyReleaseNotes(version: string) {
   openExternalLink(
-    `https://github.com/${Constants.REPO_SLUG}/releases/tag/${version}` as Link,
+    `https://github.com/${APPLICATION.REPO_SLUG}/releases/tag/${version}` as Link,
   );
 }
 

--- a/src/renderer/utils/notifications/notifications.ts
+++ b/src/renderer/utils/notifications/notifications.ts
@@ -2,6 +2,7 @@ import { AxiosError } from 'axios';
 
 import { logError, logWarn } from '../../../shared/logger';
 
+import { Constants } from '../../constants';
 import type {
   Account,
   AccountNotifications,
@@ -20,7 +21,6 @@ import type {
 } from '../api/graphql/generated/graphql';
 import type { AtlassianGraphQLResponse } from '../api/types';
 import { updateTrayIcon } from '../comms';
-import { Constants } from '../constants';
 import { Errors } from '../errors';
 import { inferAtlassianProduct } from '../products';
 import { filterNotifications } from './filters';

--- a/src/renderer/utils/storage.ts
+++ b/src/renderer/utils/storage.ts
@@ -1,7 +1,7 @@
+import { Constants } from '../constants';
 import { DEFAULT_LANGUAGE } from '../i18n';
 import type { Language } from '../i18n/types';
 import type { AtlassifyState } from '../types';
-import { Constants } from './constants';
 
 export function loadState(): AtlassifyState {
   const existing = localStorage.getItem(Constants.STORAGE_KEY);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -9,7 +9,11 @@ export const APPLICATION = {
 
   WEBSITE: 'https://atlassify.io',
 
+  REPO_SLUG: 'setchy/atlassify',
+
   DEFAULT_KEYBOARD_SHORTCUT: 'CommandOrControl+Shift+G',
 
   NOTIFICATION_SOUND: 'notification.wav',
+
+  UPDATE_CHECK_INTERVAL_MS: 24 * 60 * 60 * 1000, // 24 hours
 };


### PR DESCRIPTION
This enhancement drops `update-electron-app` and uses `electron-updater` directly.

This should mean that Linux and Windows users will now received automated (scheduled) update support