### PR TITLE
fix: windows signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,16 +42,11 @@ jobs:
           APTABASE_KEY: ${{ secrets.APTABASE_KEY }}
 
       - name: Package for ${{ matrix.platform }}
-        if: matrix.platform == 'macOS'
         run: ${{ matrix.package-cmd }}
         env:
-          # ! macOS MUST sign builds.  Certificates cannot be used across platform (ie: Windows)
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-
-      - name: Package for ${{ matrix.platform }}
-        if: matrix.platform != 'macOS'
-        run: ${{ matrix.package-cmd }}
+          # Signing certificates - important to use the correct cert per platform
+          CSC_LINK: ${{ matrix.platform == 'macOS' && secrets.CSC_LINK || (matrix.platform == 'windows' && secrets.WIN_CSC_LINK || '') }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'macOS' && secrets.CSC_KEY_PASSWORD || (matrix.platform == 'windows' && secrets.WIN_CSC_KEY_PASSWORD || '') }}
 
       - name: Clean up builds
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,22 +43,17 @@ jobs:
           APTABASE_KEY: ${{ secrets.APTABASE_KEY }}
 
       - name: Package and publish for ${{ matrix.platform }}
-        if: matrix.platform == 'macOS'
         run: ${{ matrix.package-cmd }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # ! macOS MUST sign builds.  Certificates cannot be used across platform (ie: Windows)
+          # Signing certificates - important to use the correct cert per platform
+          CSC_LINK: ${{ matrix.platform == 'macOS' && secrets.CSC_LINK || (matrix.platform == 'windows' && secrets.WIN_CSC_LINK || '') }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'macOS' && secrets.CSC_KEY_PASSWORD || (matrix.platform == 'windows' && secrets.WIN_CSC_KEY_PASSWORD || '') }}
+          # macOS specific
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_ID_TEAM_ID: ${{ secrets.APPLE_ID_TEAM_ID }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           NOTARIZE: ${{ matrix.use-apple-notarization }}
-
-      - name: Package and publish for ${{ matrix.platform }}
-        if: matrix.platform != 'macOS'
-        run: ${{ matrix.package-cmd }}
-        env:
+          # General
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts


### PR DESCRIPTION
`CSC_LINK` certificate cannot be shared across platforms (macOS vs Windows, etc).  

This causes issues during the `electron-updater` auto-update lifecycle.