### PR TITLE
fix: revert `electron-menubar` to triage windows platform positioning error

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "homepage": "https://atlassify.io",
   "dependencies": {
     "electron-log": "5.4.4",
-    "electron-menubar": "10.0.2",
+    "menubar": "9.5.2",
     "electron-updater": "6.8.9",
     "i18next": "26.3.1",
     "i18next-browser-languagedetector": "8.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       electron-log:
         specifier: 5.4.4
         version: 5.4.4
-      electron-menubar:
-        specifier: 10.0.2
-        version: 10.0.2(electron@42.4.0)
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9
@@ -29,6 +26,9 @@ importers:
       i18next-browser-languagedetector:
         specifier: 8.2.1
         version: 8.2.1
+      menubar:
+        specifier: 9.5.2
+        version: 9.5.2(electron@42.4.0)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -2467,10 +2467,8 @@ packages:
     resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
     engines: {node: '>= 14'}
 
-  electron-menubar@10.0.2:
-    resolution: {integrity: sha512-KXe+tAqjGrxj7Dp/YpF6+0L7qiO3DiMht26wG+yqUJKhcthib7K0GpORWLz7KQRYWNh40t3RqQwc99fg+X+U/Q==}
-    peerDependencies:
-      electron: 42.4.0
+  electron-positioner@4.1.0:
+    resolution: {integrity: sha512-726DfbI9ZNoCg+Fcu6XLuTKTnzf+6nFqv7h+K/V6Ug7IbaPMI7s9S8URnGtWFCy5N5PL4HSzRFF2mXuinftDdg==}
 
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
@@ -3365,6 +3363,11 @@ packages:
 
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
+
+  menubar@9.5.2:
+    resolution: {integrity: sha512-yUn4jCMPOiNuqxplEE+SITlTX+Wy92ZNZaG5tsTczEvVT1El8plHR3kinOTfUPwfQcAYcWE0SLiBM41z/hS6pg==}
+    peerDependencies:
+      electron: 42.4.0
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -7742,9 +7745,7 @@ snapshots:
 
   electron-log@5.4.4: {}
 
-  electron-menubar@10.0.2(electron@42.4.0):
-    dependencies:
-      electron: 42.4.0
+  electron-positioner@4.1.0: {}
 
   electron-publish@26.15.3:
     dependencies:
@@ -8649,6 +8650,11 @@ snapshots:
   mdn-data@2.0.14: {}
 
   memoize-one@6.0.0: {}
+
+  menubar@9.5.2(electron@42.4.0):
+    dependencies:
+      electron: 42.4.0
+      electron-positioner: 4.1.0
 
   merge-stream@2.0.0: {}
 

--- a/src/main/events.test.ts
+++ b/src/main/events.test.ts
@@ -10,7 +10,7 @@ vi.mock('electron', () => ({
   } satisfies Pick<Electron.IpcMain, 'on' | 'handle'>,
 }));
 
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { handleMainEvent, onMainEvent, sendRendererEvent } from './events';
 

--- a/src/main/events.ts
+++ b/src/main/events.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import type {
   EventArgs,

--- a/src/main/handlers/app.test.ts
+++ b/src/main/handlers/app.test.ts
@@ -1,4 +1,4 @@
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { EVENTS } from '../../shared/events';
 

--- a/src/main/handlers/app.ts
+++ b/src/main/handlers/app.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron';
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { EVENTS } from '../../shared/events';
 

--- a/src/main/handlers/system.test.ts
+++ b/src/main/handlers/system.test.ts
@@ -1,4 +1,4 @@
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { EVENTS } from '../../shared/events';
 
@@ -10,6 +10,10 @@ vi.mock('electron', () => ({
   ipcMain: {
     on: (...args: unknown[]) => onMock(...args),
   } satisfies Pick<Electron.IpcMain, 'on'>,
+  globalShortcut: {
+    register: vi.fn(),
+    unregister: vi.fn(),
+  } satisfies Pick<Electron.GlobalShortcut, 'register' | 'unregister'>,
   app: {
     setLoginItemSettings: vi.fn(),
   } satisfies Pick<Electron.App, 'setLoginItemSettings'>,

--- a/src/main/handlers/system.ts
+++ b/src/main/handlers/system.ts
@@ -1,5 +1,5 @@
 import { app, globalShortcut, powerMonitor, shell } from 'electron';
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import {
   EVENTS,

--- a/src/main/handlers/tray.test.ts
+++ b/src/main/handlers/tray.test.ts
@@ -1,4 +1,4 @@
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { EVENTS } from '../../shared/events';
 

--- a/src/main/handlers/tray.ts
+++ b/src/main/handlers/tray.ts
@@ -1,4 +1,4 @@
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { EVENTS, type ITrayColorUpdate } from '../../shared/events';
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { app } from 'electron';
 import log from 'electron-log';
-import { menubar } from 'electron-menubar';
+import { menubar } from 'menubar';
 
 import { Paths, WindowConfig } from './config';
 import {
@@ -34,8 +34,8 @@ const mb = menubar({
   browserWindow: WindowConfig,
   preloadWindow: true,
   showDockIcon: false, // Hide the app from the macOS dock
-  hideOnClose: true, // Keep renderer state across WM close; Wayland-safe.
-  escapeToHide: true, // Hide the window when Escape is pressed.
+  // hideOnClose: true, // TODO - reenable once moving to electron-menubar. Keep renderer state across WM close; Wayland-safe.
+  // escapeToHide: true, // TODO - reenable once moving to electron-menubar. Hide the window when Escape is pressed.
 });
 
 const menuBuilder = new MenuBuilder(mb);

--- a/src/main/lifecycle/reset.test.ts
+++ b/src/main/lifecycle/reset.test.ts
@@ -1,4 +1,4 @@
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 vi.mock('electron', () => ({
   dialog: { showMessageBoxSync: vi.fn(() => 0) },

--- a/src/main/lifecycle/reset.ts
+++ b/src/main/lifecycle/reset.ts
@@ -1,5 +1,5 @@
 import { dialog } from 'electron';
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { APPLICATION } from '../../shared/constants';
 import { EVENTS } from '../../shared/events';

--- a/src/main/lifecycle/startup.test.ts
+++ b/src/main/lifecycle/startup.test.ts
@@ -1,4 +1,4 @@
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { initializeAppLifecycle } from './startup';
 
@@ -64,7 +64,7 @@ describe('main/lifecycle/startup.ts', () => {
       expect(logWarnMock).toHaveBeenCalled();
     });
 
-    it('delegates context-menu wiring to mb.setContextMenu', () => {
+    it.skip('delegates context-menu wiring to mb.setContextMenu', () => {
       const mb = createMb();
       const contextMenu = {} as Electron.Menu;
 

--- a/src/main/lifecycle/startup.ts
+++ b/src/main/lifecycle/startup.ts
@@ -1,5 +1,5 @@
 import { app, nativeTheme } from 'electron';
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { APPLICATION } from '../../shared/constants';
 import { EVENTS } from '../../shared/events';
@@ -9,13 +9,7 @@ import { Theme } from '../../shared/theme';
 import { sendRendererEvent } from '../events';
 
 /**
- * Set up core application lifecycle events including tray ready setup,
- * protocol URL handling, and single-instance enforcement.
- *
- * The tray's context-menu wiring (Linux `setContextMenu` vs macOS/Windows
- * right-click popup) and the macOS `setIgnoreDoubleClickEvents` default
- * are owned by `electron-menubar` — pass `contextMenu` here and the library
- * picks the right binding per platform.
+ * Set up core application lifecycle events.
  *
  * @param mb - The menubar instance to attach lifecycle events to.
  * @param contextMenu - The tray context menu to pop up on right-click.
@@ -27,7 +21,14 @@ export function initializeAppLifecycle(
   mb.on('ready', () => {
     mb.app.setAppUserModelId(APPLICATION.ID);
     mb.tray.setToolTip(APPLICATION.NAME);
-    mb.setContextMenu(contextMenu);
+
+    mb.tray.setIgnoreDoubleClickEvents(true);
+
+    mb.tray.on('right-click', (_event, bounds) => {
+      mb.tray.popUpContextMenu(contextMenu, { x: bounds.x, y: bounds.y });
+    });
+    // TODO - reenable once moving to electron-menubar.
+    // mb.setContextMenu(contextMenu);
   });
 
   /**

--- a/src/main/lifecycle/window.test.ts
+++ b/src/main/lifecycle/window.test.ts
@@ -1,4 +1,4 @@
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import type MenuBuilder from '../menu';
 import {
@@ -87,6 +87,9 @@ describe('main/lifecycle/window.ts', () => {
           on: vi.fn(),
         },
       },
+      positioner: {
+        move: vi.fn(),
+      },
     } as unknown as Menubar;
     menuBuilder = {
       setWindowVisibility: vi.fn(),
@@ -118,7 +121,7 @@ describe('main/lifecycle/window.ts', () => {
     );
   });
 
-  it('does not register a close, before-input-event, or its own escape handler (library owns those)', () => {
+  it.skip('does not register a close, before-input-event, or its own escape handler (library owns those)', () => {
     configureWindowEvents(menubar, menuBuilder);
 
     expect(menubar.window?.on).not.toHaveBeenCalledWith(
@@ -199,15 +202,16 @@ describe('main/lifecycle/window.ts', () => {
     });
   });
 
-  describe('devtools-closed handler', () => {
-    it('delegates re-centering to mb.recenterOnTray()', () => {
-      configureWindowEvents(menubar, menuBuilder);
+  // TODO - reenable once moving to electron-menubar.
+  // describe('devtools-closed handler', () => {
+  //   it('delegates re-centering to mb.recenterOnTray()', () => {
+  //     configureWindowEvents(menubar, menuBuilder);
 
-      findWebContentsHandler(menubar, 'devtools-closed')?.();
+  //     findWebContentsHandler(menubar, 'devtools-closed')?.();
 
-      expect(menubar.recenterOnTray).toHaveBeenCalled();
-    });
-  });
+  //     expect(menubar.recenterOnTray).toHaveBeenCalled();
+  //   });
+  // });
 
   describe('window-all-closed handler', () => {
     it('keeps the app alive when not quitting', () => {

--- a/src/main/lifecycle/window.ts
+++ b/src/main/lifecycle/window.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron';
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { isMacOS } from '../../shared/platform';
 
@@ -69,6 +69,16 @@ export function configureWindowEvents(
   });
 
   /**
+   * Listen for 'before-input-event' to detect Escape key presses and hide the window.
+   */
+  mb.window.webContents.on('before-input-event', (event, input) => {
+    if (input.key === 'Escape') {
+      mb.hideWindow();
+      event.preventDefault();
+    }
+  });
+
+  /**
    * Safety net: if the WM tears down the window despite our `hideOnClose`
    * preventDefault (a known Wayland edge case), suppress the default
    * Electron quit so the tray icon stays put and `menubar` can recreate
@@ -109,8 +119,12 @@ export function configureWindowEvents(
       return;
     }
 
+    const trayBounds = mb.tray.getBounds();
+    mb.window.setSize(WindowConfig.width, WindowConfig.height);
+    mb.positioner.move('trayCenter', trayBounds);
+
     mb.window.setSize(WindowConfig.width!, WindowConfig.height!);
-    mb.recenterOnTray();
+    // mb.recenterOnTray();
     mb.window.resizable = false;
     mb.window.setAlwaysOnTop(keepWindowOnBlur);
   });

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -1,6 +1,6 @@
 import { Menu, shell } from 'electron';
-import type { Menubar } from 'electron-menubar';
 import { autoUpdater } from 'electron-updater';
+import type { Menubar } from 'menubar';
 
 import type { Mock } from 'vitest';
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,6 +1,6 @@
 import { Menu, MenuItem, shell } from 'electron';
-import type { Menubar } from 'electron-menubar';
 import { autoUpdater } from 'electron-updater';
+import type { Menubar } from 'menubar';
 
 import { APPLICATION } from '../shared/constants';
 import { isMacOS } from '../shared/platform';

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1,5 +1,5 @@
 import { dialog } from 'electron';
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { APPLICATION } from '../shared/constants';
 import { logError, logInfo } from '../shared/logger';

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,6 +1,6 @@
 import { dialog, type MessageBoxOptions } from 'electron';
-import type { Menubar } from 'electron-menubar';
 import { autoUpdater } from 'electron-updater';
+import type { Menubar } from 'menubar';
 
 import { APPLICATION } from '../shared/constants';
 import { logError, logInfo } from '../shared/logger';

--- a/src/main/utils.test.ts
+++ b/src/main/utils.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 const isPackagedMock = vi.fn();
 vi.mock('electron', () => ({

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { app, shell } from 'electron';
 import log from 'electron-log';
-import type { Menubar } from 'electron-menubar';
+import type { Menubar } from 'menubar';
 
 import { APPLICATION } from '../shared/constants';
 import { logError, logInfo } from '../shared/logger';


### PR DESCRIPTION
Windows users on `v3.10.0` have reported window positioning errors since upgrading.

Reverting `electron-menubar` to `menubar` to see if that helps