### PR TITLE
refactor: update urls (api and web) to home.atlassian.com

### DIFF
--- a/src/renderer/components/Sidebar.test.tsx
+++ b/src/renderer/components/Sidebar.test.tsx
@@ -89,7 +89,7 @@ describe('renderer/components/Sidebar.tsx', () => {
       await userEvent.click(screen.getByTestId('sidebar-notifications'));
 
       expect(openExternalLinkSpy).toHaveBeenCalledWith(
-        'https://team.atlassian.com/notifications',
+        'https://home.atlassian.com/notifications',
       );
     });
 

--- a/src/renderer/hooks/useNotifications.test.tsx
+++ b/src/renderer/hooks/useNotifications.test.tsx
@@ -20,7 +20,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
 
   describe('fetchNotifications', () => {
     it('fetchNotifications - unread only', async () => {
-      nock('https://team.atlassian.net')
+      nock('https://home.atlassian.com')
         .post('/gateway/api/graphql')
         .reply(200, {
           data: {
@@ -60,7 +60,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
         fetchOnlyUnreadNotifications: false,
       });
 
-      nock('https://team.atlassian.net')
+      nock('https://home.atlassian.com')
         .post('/gateway/api/graphql')
         .reply(200, {
           data: {
@@ -100,7 +100,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
         fetchOnlyUnreadNotifications: false,
       });
 
-      nock('https://team.atlassian.net')
+      nock('https://home.atlassian.com')
         .post('/gateway/api/graphql')
         .reply(200, {
           data: {
@@ -131,7 +131,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
 
   it('markNotificationsRead', async () => {
     // Mock initial fetch
-    nock('https://team.atlassian.net')
+    nock('https://home.atlassian.com')
       .post('/gateway/api/graphql')
       .reply(200, {
         data: {
@@ -151,10 +151,10 @@ describe('renderer/hooks/useNotifications.ts', () => {
       });
 
     // Mock the markNotificationsAsRead mutation
-    nock('https://team.atlassian.net').post('/gateway/api/graphql').reply(200);
+    nock('https://home.atlassian.com').post('/gateway/api/graphql').reply(200);
 
     // Mock the automatic refetch after mutation
-    nock('https://team.atlassian.net')
+    nock('https://home.atlassian.com')
       .post('/gateway/api/graphql')
       .reply(200, {
         data: {
@@ -194,7 +194,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
 
   it('markNotificationsUnread', async () => {
     // Mock initial fetch
-    nock('https://team.atlassian.net')
+    nock('https://home.atlassian.com')
       .post('/gateway/api/graphql')
       .reply(200, {
         data: {
@@ -214,10 +214,10 @@ describe('renderer/hooks/useNotifications.ts', () => {
       });
 
     // Mock the markNotificationsAsUnread mutation
-    nock('https://team.atlassian.net').post('/gateway/api/graphql').reply(200);
+    nock('https://home.atlassian.com').post('/gateway/api/graphql').reply(200);
 
     // Mock the automatic refetch after mutation
-    nock('https://team.atlassian.net')
+    nock('https://home.atlassian.com')
       .post('/gateway/api/graphql')
       .reply(200, {
         data: {

--- a/src/renderer/utils/api/request.test.ts
+++ b/src/renderer/utils/api/request.test.ts
@@ -11,7 +11,7 @@ import {
   performRequestForCredentials,
 } from './request';
 
-const url = 'https://team.atlassian.net/gateway/api/graphql' as Link;
+const url = 'https://home.atlassian.com/gateway/api/graphql' as Link;
 
 describe('renderer/utils/api/request.ts', () => {
   beforeEach(() => {

--- a/src/renderer/utils/system/links.test.ts
+++ b/src/renderer/utils/system/links.test.ts
@@ -60,7 +60,7 @@ describe('renderer/utils/system/links.ts', () => {
     openAccountProfile(mockAtlassianCloudAccount);
 
     expect(openExternalLinkSpy).toHaveBeenCalledWith(
-      'https://team.atlassian.com/people/123456789',
+      'https://home.atlassian.com/people/123456789',
     );
   });
 

--- a/src/renderer/utils/system/links.ts
+++ b/src/renderer/utils/system/links.ts
@@ -6,15 +6,15 @@ import { openExternalLink, trackEvent } from './comms';
 
 export const URLs = {
   ATLASSIAN: {
-    API: 'https://team.atlassian.net/gateway/api/graphql' as Link,
+    API: 'https://home.atlassian.com/gateway/api/graphql' as Link,
     DOCS: {
       API_TOKEN:
         'https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/#Create-an-API-token-with-scopes' as Link,
     },
     WEB: {
       BITBUCKET_HOME: 'https://bitbucket.org' as Link,
-      MY_NOTIFICATIONS: 'https://team.atlassian.com/notifications' as Link,
-      PEOPLE: 'https://team.atlassian.com/people' as Link,
+      MY_NOTIFICATIONS: 'https://home.atlassian.com/notifications' as Link,
+      PEOPLE: 'https://home.atlassian.com/people' as Link,
       SECURITY_TOKENS:
         'https://id.atlassian.com/manage-profile/security/api-tokens' as Link,
     },


### PR DESCRIPTION
Update API and WEB urls to use `home.atlassian.com` instead of `team.atlassian.com` and `team.atlassian.net`