### PR TITLE
feat(api): paginate results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 
 # Dependency directories
 node_modules/
+.pnpm-store/
 
 # Generated GraphQL Files
 schema.graphql

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -35,7 +35,10 @@ export const Constants = {
   // Query garbage collection time in milliseconds - how long unused cache data stays in memory
   QUERY_GC_TIME_MS: 10 * 60 * 1000, // 10 minutes
 
-  // Maximum number of notifications to fetch per account
+  // Maximum number of notifications returned per GraphQL request (API-enforced limit)
+  NOTIFICATIONS_PAGE_SIZE: 100,
+
+  // Maximum number of notifications to fetch per account, across paginated requests
   MAX_NOTIFICATIONS_PER_ACCOUNT: 999,
 
   // Threshold for determining if a notification content block is "long" and needs truncating

--- a/src/renderer/utils/api/client.graphql
+++ b/src/renderer/utils/api/client.graphql
@@ -47,16 +47,19 @@ query MyNotifications(
   $readState: InfluentsNotificationReadState
   $flat: Boolean = true
   $first: Int
+  $after: String
 ) {
   notifications {
     unseenNotificationCount
     notificationFeed(
       flat: $flat
       first: $first
+      after: $after
       filter: { readStateFilter: $readState }
     ) {
       pageInfo {
         hasNextPage
+        endCursor
       }
       nodes {
         ...AtlassianNotification

--- a/src/renderer/utils/api/client.test.ts
+++ b/src/renderer/utils/api/client.test.ts
@@ -61,7 +61,8 @@ describe('renderer/utils/api/client.ts', () => {
       mockAtlassianCloudAccount,
       MyNotificationsDocument,
       {
-        first: Constants.MAX_NOTIFICATIONS_PER_ACCOUNT,
+        first: Constants.NOTIFICATIONS_PAGE_SIZE,
+        after: undefined,
         flat: false,
         readState: 'unread',
       },

--- a/src/renderer/utils/api/client.ts
+++ b/src/renderer/utils/api/client.ts
@@ -84,18 +84,24 @@ export function getAuthenticatedUser(
 /**
  * List all notifications for the current user.
  *
+ * The Atlassian GraphQL API limits each request to `Constants.NOTIFICATIONS_PAGE_SIZE`
+ * notifications, so callers should page through results using the `after` cursor.
+ *
  * @param account - The account to fetch notifications for.
+ * @param after - The cursor to fetch the next page of notifications from.
  * @returns Promise resolving to the GraphQL response containing the notification feed.
  *
  * Endpoint documentation: https://developer.atlassian.com/platform/atlassian-graphql-api/graphql
  */
 export function getNotificationsForUser(
   account: Account,
+  after?: string,
 ): Promise<AtlassianGraphQLResponse<MyNotificationsQuery>> {
   const settings = useSettingsStore.getState();
 
   return performRequestForAccount(account, MyNotificationsDocument, {
-    first: Constants.MAX_NOTIFICATIONS_PER_ACCOUNT,
+    first: Constants.NOTIFICATIONS_PAGE_SIZE,
+    after,
     flat: !settings.groupNotificationsByTitle,
     readState: settings.fetchOnlyUnreadNotifications
       ? InfluentsNotificationReadState.Unread

--- a/src/renderer/utils/api/graphql/generated/graphql.ts
+++ b/src/renderer/utils/api/graphql/generated/graphql.ts
@@ -71,10 +71,11 @@ export type MyNotificationsQueryVariables = Exact<{
   readState?: InfluentsNotificationReadState | null | undefined;
   flat?: boolean | null | undefined;
   first?: number | null | undefined;
+  after?: string | null | undefined;
 }>;
 
 
-export type MyNotificationsQuery = { notifications: { unseenNotificationCount: number, notificationFeed: { pageInfo: { hasNextPage: boolean }, nodes: Array<{ groupId: string, groupSize: number, additionalActors: Array<{ displayName: string | null, avatarURL: string | null }>, headNotification: { notificationId: string, timestamp: string, readState: InfluentsNotificationReadState, category: InfluentsNotificationCategory, content: { type: string, message: string, url: string | null, bodyItems: Array<{ appearance: string | null, author: { actorType: InfluentsNotificationActorType | null, ari: string | null, avatarURL: string | null, displayName: string | null } | null, document: { data: string | null, format: string | null } | null }> | null, entity: { title: string | null, iconUrl: string | null, url: string | null } | null, path: Array<{ title: string | null, iconUrl: string | null, url: string | null }> | null, actor: { displayName: string | null, avatarURL: string | null } }, analyticsAttributes: Array<{ key: string | null, value: string | null }> | null } }> } } | null };
+export type MyNotificationsQuery = { notifications: { unseenNotificationCount: number, notificationFeed: { pageInfo: { hasNextPage: boolean, endCursor: string | null }, nodes: Array<{ groupId: string, groupSize: number, additionalActors: Array<{ displayName: string | null, avatarURL: string | null }>, headNotification: { notificationId: string, timestamp: string, readState: InfluentsNotificationReadState, category: InfluentsNotificationCategory, content: { type: string, message: string, url: string | null, bodyItems: Array<{ appearance: string | null, author: { actorType: InfluentsNotificationActorType | null, ari: string | null, avatarURL: string | null, displayName: string | null } | null, document: { data: string | null, format: string | null } | null }> | null, entity: { title: string | null, iconUrl: string | null, url: string | null } | null, path: Array<{ title: string | null, iconUrl: string | null, url: string | null }> | null, actor: { displayName: string | null, avatarURL: string | null } }, analyticsAttributes: Array<{ key: string | null, value: string | null }> | null } }> } } | null };
 
 export type AtlassianNotificationFragment = { groupId: string, groupSize: number, additionalActors: Array<{ displayName: string | null, avatarURL: string | null }>, headNotification: { notificationId: string, timestamp: string, readState: InfluentsNotificationReadState, category: InfluentsNotificationCategory, content: { type: string, message: string, url: string | null, bodyItems: Array<{ appearance: string | null, author: { actorType: InfluentsNotificationActorType | null, ari: string | null, avatarURL: string | null, displayName: string | null } | null, document: { data: string | null, format: string | null } | null }> | null, entity: { title: string | null, iconUrl: string | null, url: string | null } | null, path: Array<{ title: string | null, iconUrl: string | null, url: string | null }> | null, actor: { displayName: string | null, avatarURL: string | null } }, analyticsAttributes: Array<{ key: string | null, value: string | null }> | null } };
 
@@ -275,16 +276,18 @@ export const RetrieveNotificationsByGroupIdDocument = new TypedDocumentString(`
   readState
 }`) as unknown as TypedDocumentString<RetrieveNotificationsByGroupIdQuery, RetrieveNotificationsByGroupIdQueryVariables>;
 export const MyNotificationsDocument = new TypedDocumentString(`
-    query MyNotifications($readState: InfluentsNotificationReadState, $flat: Boolean = true, $first: Int) {
+    query MyNotifications($readState: InfluentsNotificationReadState, $flat: Boolean = true, $first: Int, $after: String) {
   notifications {
     unseenNotificationCount
     notificationFeed(
       flat: $flat
       first: $first
+      after: $after
       filter: { readStateFilter: $readState }
     ) {
       pageInfo {
         hasNextPage
+        endCursor
       }
       nodes {
         ...AtlassianNotification

--- a/src/renderer/utils/api/pagination.test.ts
+++ b/src/renderer/utils/api/pagination.test.ts
@@ -1,0 +1,122 @@
+import { mockAtlassianCloudAccount } from '../../__mocks__/account-mocks';
+
+import { Constants } from '../../constants';
+
+import type { AtlassianGraphQLResponse } from './types';
+
+import * as client from './client';
+import type {
+  AtlassianNotificationFragment,
+  MyNotificationsQuery,
+} from './graphql/generated/graphql';
+import { fetchAccountNotificationFeed } from './pagination';
+
+function createMockNode(groupId: string): AtlassianNotificationFragment {
+  return {
+    groupId,
+    groupSize: 1,
+    additionalActors: [],
+    headNotification: null,
+  } as unknown as AtlassianNotificationFragment;
+}
+
+function createMockPage(
+  nodes: AtlassianNotificationFragment[],
+  endCursor: string | null,
+  unseenNotificationCount = 0,
+): AtlassianGraphQLResponse<MyNotificationsQuery> {
+  return {
+    data: {
+      notifications: {
+        unseenNotificationCount,
+        notificationFeed: {
+          pageInfo: { hasNextPage: true, endCursor },
+          nodes,
+        },
+      },
+    },
+  } as unknown as AtlassianGraphQLResponse<MyNotificationsQuery>;
+}
+
+describe('renderer/utils/api/pagination.ts', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return all nodes and stop when a partial page is returned', async () => {
+    const fullPage = Array.from(
+      { length: Constants.NOTIFICATIONS_PAGE_SIZE },
+      (_, i) => createMockNode(`full-${i}`),
+    );
+    const partialPage = [createMockNode('partial-0')];
+
+    vi.spyOn(client, 'getNotificationsForUser')
+      .mockResolvedValueOnce(createMockPage(fullPage, 'cursor-1', 5))
+      .mockResolvedValueOnce(createMockPage(partialPage, null, 5));
+
+    const result = await fetchAccountNotificationFeed(
+      mockAtlassianCloudAccount,
+    );
+
+    expect(client.getNotificationsForUser).toHaveBeenCalledTimes(2);
+    expect(client.getNotificationsForUser).toHaveBeenNthCalledWith(
+      2,
+      mockAtlassianCloudAccount,
+      'cursor-1',
+    );
+    expect(result.nodes).toHaveLength(Constants.NOTIFICATIONS_PAGE_SIZE + 1);
+    expect(result.unseenNotificationCount).toBe(5);
+    expect(result.hasMoreNotifications).toBe(false);
+  });
+
+  it('should stop paginating once the account cap is reached', async () => {
+    const pageCount = Math.ceil(
+      Constants.MAX_NOTIFICATIONS_PER_ACCOUNT /
+        Constants.NOTIFICATIONS_PAGE_SIZE,
+    );
+    const fullPage = Array.from(
+      { length: Constants.NOTIFICATIONS_PAGE_SIZE },
+      (_, i) => createMockNode(`node-${i}`),
+    );
+
+    const spy = vi.spyOn(client, 'getNotificationsForUser');
+    for (let i = 0; i < pageCount; i++) {
+      spy.mockResolvedValueOnce(createMockPage(fullPage, `cursor-${i}`));
+    }
+
+    const result = await fetchAccountNotificationFeed(
+      mockAtlassianCloudAccount,
+    );
+
+    expect(client.getNotificationsForUser).toHaveBeenCalledTimes(pageCount);
+    expect(result.hasMoreNotifications).toBe(true);
+  });
+
+  it('should throw when the GraphQL response contains errors', async () => {
+    vi.spyOn(client, 'getNotificationsForUser').mockResolvedValueOnce({
+      errors: [{ message: 'Something went wrong' }],
+    } as unknown as AtlassianGraphQLResponse<MyNotificationsQuery>);
+
+    await expect(
+      fetchAccountNotificationFeed(mockAtlassianCloudAccount),
+    ).rejects.toThrow();
+  });
+
+  it('should handle a response missing pageInfo/nodes gracefully', async () => {
+    vi.spyOn(client, 'getNotificationsForUser').mockResolvedValueOnce({
+      data: {
+        notifications: {
+          unseenNotificationCount: 0,
+          notificationFeed: {},
+        },
+      },
+    } as unknown as AtlassianGraphQLResponse<MyNotificationsQuery>);
+
+    const result = await fetchAccountNotificationFeed(
+      mockAtlassianCloudAccount,
+    );
+
+    expect(result.nodes).toEqual([]);
+    expect(result.hasMoreNotifications).toBe(false);
+  });
+});

--- a/src/renderer/utils/api/pagination.ts
+++ b/src/renderer/utils/api/pagination.ts
@@ -1,27 +1,62 @@
+import { AxiosError } from 'axios';
+
 import { Constants } from '../../constants';
 
-import type { AtlassianGraphQLResponse } from './types';
+import type { Account } from '../../types';
 
-import { rendererLogWarn } from '../core/logger';
+import { Errors } from '../core/errors';
+import { getNotificationsForUser } from './client';
+import type { AtlassianNotificationFragment } from './graphql/generated/graphql';
+
+export interface NotificationFeedResult {
+  nodes: AtlassianNotificationFragment[];
+  unseenNotificationCount: number;
+  hasMoreNotifications: boolean;
+}
 
 /**
- * Atlassian GraphQL response always returns true for Relay PageInfo `hasNextPage` even when there are no more pages.
- * Instead we can check the extensions response size to determine if there are more notifications.
+ * Fetch every page of notifications for an account.
+ *
+ * The Atlassian GraphQL API limits each request to `Constants.NOTIFICATIONS_PAGE_SIZE`
+ * notifications, so pages are fetched sequentially using the `after` cursor until either
+ * a partial page is returned or `Constants.MAX_NOTIFICATIONS_PER_ACCOUNT` notifications
+ * have been collected.
+ *
+ * The API's `pageInfo.hasNextPage` always returns `true`, even on the last page, so a page
+ * returning fewer than `Constants.NOTIFICATIONS_PAGE_SIZE` nodes is treated as the end of the feed.
+ *
+ * @param account - The account to fetch notifications for.
+ * @returns The combined notification nodes across all fetched pages, along with whether more notifications remain.
  */
-export function determineIfMorePagesAvailable<TResult>(
-  res: AtlassianGraphQLResponse<TResult>,
-): boolean {
-  try {
-    return (
-      res.extensions.notifications.response_info.responseSize ===
-      Constants.MAX_NOTIFICATIONS_PER_ACCOUNT
-    );
-  } catch (_err) {
-    rendererLogWarn(
-      'determineIfMorePagesAvailable',
-      'Response did not contain extensions object, assuming no more pages',
-    );
-  }
+export async function fetchAccountNotificationFeed(
+  account: Account,
+): Promise<NotificationFeedResult> {
+  const nodes: AtlassianNotificationFragment[] = [];
+  let unseenNotificationCount = 0;
+  let after: string | undefined;
+  let isFullPage: boolean;
 
-  return false;
+  do {
+    const res = await getNotificationsForUser(account, after);
+
+    if (res.errors) {
+      throw new AxiosError(Errors.BAD_REQUEST.title);
+    }
+
+    const feed = res.data.notifications.notificationFeed;
+    unseenNotificationCount = res.data.notifications.unseenNotificationCount;
+    nodes.push(...(feed.nodes ?? []));
+
+    isFullPage = feed.nodes?.length === Constants.NOTIFICATIONS_PAGE_SIZE;
+    after = feed.pageInfo?.endCursor;
+  } while (
+    isFullPage &&
+    nodes.length < Constants.MAX_NOTIFICATIONS_PER_ACCOUNT
+  );
+
+  return {
+    nodes,
+    unseenNotificationCount,
+    hasMoreNotifications: isFullPage,
+  };
 }

--- a/src/renderer/utils/notifications/fetch.ts
+++ b/src/renderer/utils/notifications/fetch.ts
@@ -1,14 +1,10 @@
-import { AxiosError } from 'axios';
-
 import { useAccountsStore } from '../../stores';
 
 import type { AccountNotifications, AtlassifyNotification } from '../../types';
 
-import { getNotificationsForUser } from '../api/client';
 import { determineFailureType } from '../api/errors';
-import { determineIfMorePagesAvailable } from '../api/pagination';
+import { fetchAccountNotificationFeed } from '../api/pagination';
 import { transformNotifications } from '../api/transform';
-import { Errors } from '../core/errors';
 import { rendererLogError } from '../core/logger';
 import { getFlattenedNotificationsByProduct } from './group';
 
@@ -44,7 +40,7 @@ function getNotifications() {
   return accounts.map((account) => {
     return {
       account,
-      notifications: getNotificationsForUser(account),
+      notifications: fetchAccountNotificationFeed(account),
     };
   });
 }
@@ -68,22 +64,15 @@ export async function getAllNotifications(): Promise<AccountNotifications[]> {
         try {
           const res = await accountNotifications.notifications;
 
-          if (res.errors) {
-            throw new AxiosError(Errors.BAD_REQUEST.title);
-          }
-
-          const rawNotifications =
-            res.data.notifications.notificationFeed.nodes;
-
           const notifications = await transformNotifications(
-            rawNotifications,
+            res.nodes,
             accountNotifications.account,
           );
 
           return {
             account: accountNotifications.account,
             notifications: notifications,
-            hasMoreNotifications: determineIfMorePagesAvailable(res),
+            hasMoreNotifications: res.hasMoreNotifications,
             error: null,
           };
         } catch (err) {


### PR DESCRIPTION
recently the Atlassian API has silently enforced a maximum of `100` results within the notification fee.  Requesting more previously worked, but is now truncated.

This PR adds pagination support for fetching more pages.  Still capped at `999` max results, as per previous behavior