### PR TITLE
fix(api): resolve and use routing ari for grouped notification interactions

### DIFF
--- a/docs/src/faqs/2.md
+++ b/docs/src/faqs/2.md
@@ -1,14 +1,30 @@
 ---
-title: "How do Filters work?"
+title: "My notification feed is empty or missing notifications, how do I fix it?"
 ---
-
-Filters in Atlassify help you manage which notifications are shown in the app, allowing you to concentrate on the most crucial ones for your workflow.
-
-<br />
-
-Filters can be accessed from the Atlassify sidebar. By default, all notifications are shown.
+If your notification feed appears empty or is missing notifications, there are a few things you can check.
 
 <br />
 
-If you apply filters, your inbox will display notifications based on a `LOGICAL AND` condition.
+### 1. Check the **Show only unread** toggle
 
+By default, Atlassify only shows unread notifications. If you've read all of your notifications, the feed will appear empty. Try toggling **Show only unread** (found in the sidebar) to confirm that previously-read notifications are still being fetched.
+
+<br />
+
+### 2. Verify the notification exists in Atlassian
+
+Confirm the missing notification is actually visible in Atlassian by checking [your notification center](https://home.atlassian.com/notifications). If it isn't there, it's not an Atlassify issue.
+
+<br />
+
+### 3. Configure **site hostnames** if notifications are missing from a specific site
+
+Site hostnames are **optional** and only need to be configured if you notice notifications missing from your feed for a specific Atlassian site (e.g. `your-domain.atlassian.net`).
+
+<br />
+
+Atlassify normally discovers all of your accessible Atlassian sites automatically. In rare cases, a site may not be discoverable this way, which can cause its notifications to be left out of your feed.
+
+<br />
+
+If that happens, add the site's hostname via **Accounts → ⚙️ (next to the account)** to help Atlassify resolve it directly.

--- a/docs/src/faqs/3.md
+++ b/docs/src/faqs/3.md
@@ -1,16 +1,14 @@
 ---
-title: "Something is not working as expected, how can I debug Atlassify?"
+title: "How do Filters work?"
 ---
-Using **Chrome Developer Tools** (console logs, network requests, etc):
-- All platforms: right click tray icon then _Developer → Toggle Developer Tools_
-- macOS: `command + opt + i`
-- Windows: `ctrl + shift + i`
-- Linux: `ctrl + shift + i`
+
+Filters in Atlassify help you manage which notifications are shown in the app, allowing you to concentrate on the most crucial ones for your workflow.
 
 <br />
 
-Using **Application Log Files**:
-- All platforms: right click tray icon then _Developer → View Application Logs_
-- macOS: `~/Library/Logs/atlassify`
-- Windows: `%USERPROFILE%\\AppData\\Roaming\\atlassify\\logs`
-- Linux: `~/.config/atlassify/logs`
+Filters can be accessed from the Atlassify sidebar. By default, all notifications are shown.
+
+<br />
+
+If you apply filters, your inbox will display notifications based on a `LOGICAL AND` condition.
+

--- a/docs/src/faqs/4.md
+++ b/docs/src/faqs/4.md
@@ -1,4 +1,16 @@
 ---
-title: "Does Atlassify support Atlassian Data Center or Server products?"
+title: "Something is not working as expected, how can I debug Atlassify?"
 ---
-Currently Atlassify supports Atlassian Cloud products. If you would like to see support for other product types, please raise a [GitHub issue](https://github.com/setchy/atlassify/issues).
+Using **Chrome Developer Tools** (console logs, network requests, etc):
+- All platforms: right click tray icon then _Developer → Toggle Developer Tools_
+- macOS: `command + opt + i`
+- Windows: `ctrl + shift + i`
+- Linux: `ctrl + shift + i`
+
+<br />
+
+Using **Application Log Files**:
+- All platforms: right click tray icon then _Developer → View Application Logs_
+- macOS: `~/Library/Logs/atlassify`
+- Windows: `%USERPROFILE%\\AppData\\Roaming\\atlassify\\logs`
+- Linux: `~/.config/atlassify/logs`

--- a/docs/src/faqs/5.md
+++ b/docs/src/faqs/5.md
@@ -1,8 +1,4 @@
 ---
-title: "How can I contribute to Atlassify?"
+title: "Does Atlassify support Atlassian Data Center or Server products?"
 ---
-You can contribute to Atlassify by opening an issue or pull request on GitHub at [setchy/atlassify](https://github.com/setchy/atlassify).
-
-<br />
-
-Check out our [open issues](https://github.com/setchy/atlassify/issues) and see if there is any existing ideas that you would like to work on.
+Currently Atlassify supports Atlassian Cloud products. If you would like to see support for other product types, please raise a [GitHub issue](https://github.com/setchy/atlassify/issues).

--- a/docs/src/faqs/6.md
+++ b/docs/src/faqs/6.md
@@ -1,12 +1,8 @@
 ---
-title: "What are site hostnames and do I need to configure them?"
+title: "How can I contribute to Atlassify?"
 ---
-Site hostnames are **optional** and only need to be configured if you notice notifications missing from your feed for a specific Atlassian site (e.g. `your-domain.atlassian.net`).
+You can contribute to Atlassify by opening an issue or pull request on GitHub at [setchy/atlassify](https://github.com/setchy/atlassify).
 
 <br />
 
-Atlassify normally discovers all of your accessible Atlassian sites automatically. In rare cases, a site may not be discoverable this way, which can cause its notifications to be left out of your feed.
-
-<br />
-
-If that happens, add the site's hostname via **Accounts → ⚙️ (next to the account)** to help Atlassify resolve it directly.
+Check out our [open issues](https://github.com/setchy/atlassify/issues) and see if there is any existing ideas that you would like to work on.

--- a/src/renderer/hooks/useNotifications.ts
+++ b/src/renderer/hooks/useNotifications.ts
@@ -367,6 +367,7 @@ export const useNotifications = (): UseNotificationsResult => {
         const notificationIDs = await resolveNotificationIdsForGroup(
           account,
           scopedNotifications,
+          cloudId,
         );
         await markAsApiFn(account, notificationIDs, cloudId);
       }

--- a/src/renderer/utils/api/client.graphql
+++ b/src/renderer/utils/api/client.graphql
@@ -36,12 +36,14 @@ query RetrieveNotificationsByGroupId(
   $groupId: String!
   $first: Int
   $readState: InfluentsNotificationReadState
+  $collabContextRoutingAri: String
 ) {
   notifications {
     notificationGroup(
       groupId: $groupId
       first: $first
       filter: { readStateFilter: $readState }
+      collabContextRoutingAri: $collabContextRoutingAri
     ) {
       nodes {
         ...GroupNotificationDetails

--- a/src/renderer/utils/api/client.test.ts
+++ b/src/renderer/utils/api/client.test.ts
@@ -12,6 +12,7 @@ import type {
 } from './types';
 
 import * as client from './client';
+import { getCollabContextRoutingAri } from './collabContextRouting';
 import {
   MeDocument,
   MyNotificationsDocument,
@@ -86,7 +87,7 @@ describe('renderer/utils/api/client.ts', () => {
         after: undefined,
         flat: false,
         readState: 'unread',
-        collabContextRoutingAri: `ari:cloud:platform::site/${mockCloudID}`,
+        collabContextRoutingAri: getCollabContextRoutingAri(mockCloudID),
       },
     );
   });
@@ -119,7 +120,7 @@ describe('renderer/utils/api/client.ts', () => {
       expect.stringContaining('mutation MarkAsRead'),
       {
         notificationIDs: [mockSingleAtlassifyNotification.id],
-        collabContextRoutingAri: `ari:cloud:platform::site/${mockCloudID}`,
+        collabContextRoutingAri: getCollabContextRoutingAri(mockCloudID),
       },
     );
   });
@@ -152,7 +153,7 @@ describe('renderer/utils/api/client.ts', () => {
       expect.stringContaining('mutation MarkAsUnread'),
       {
         notificationIDs: [mockSingleAtlassifyNotification.id],
-        collabContextRoutingAri: `ari:cloud:platform::site/${mockCloudID}`,
+        collabContextRoutingAri: getCollabContextRoutingAri(mockCloudID),
       },
     );
   });
@@ -202,6 +203,33 @@ describe('renderer/utils/api/client.ts', () => {
           groupId: mockSingleAtlassifyNotification.notificationGroup.id,
           first: mockGroupSize,
           readState: null,
+        },
+      );
+    });
+
+    it('getNotificationsByGroupId - should scope mutation to cloud ID when provided', async () => {
+      const mockGroupSize = 5;
+      const mockCloudID = 'mock-cloud-id' as CloudID;
+
+      useSettingsStore.setState({
+        fetchOnlyUnreadNotifications: false,
+      });
+
+      await client.getNotificationsByGroupId(
+        mockAtlassianCloudAccount,
+        mockSingleAtlassifyNotification.notificationGroup.id,
+        mockGroupSize,
+        mockCloudID,
+      );
+
+      expect(request.performRequestForAccount).toHaveBeenCalledWith(
+        mockAtlassianCloudAccount,
+        expect.stringContaining('query RetrieveNotificationsByGroupId'),
+        {
+          groupId: mockSingleAtlassifyNotification.notificationGroup.id,
+          first: mockGroupSize,
+          readState: null,
+          collabContextRoutingAri: getCollabContextRoutingAri(mockCloudID),
         },
       );
     });

--- a/src/renderer/utils/api/client.ts
+++ b/src/renderer/utils/api/client.ts
@@ -18,6 +18,7 @@ import type {
   JiraProjectType,
 } from './types';
 
+import { getCollabContextRoutingAri } from './collabContextRouting';
 import {
   InfluentsNotificationReadState,
   MarkAsReadDocument,
@@ -108,9 +109,7 @@ export function getNotificationsForUser(
     readState: settings.fetchOnlyUnreadNotifications
       ? InfluentsNotificationReadState.Unread
       : null,
-    collabContextRoutingAri: cloudId
-      ? `ari:cloud:platform::site/${cloudId}`
-      : undefined,
+    collabContextRoutingAri: getCollabContextRoutingAri(cloudId),
   });
 }
 
@@ -130,9 +129,7 @@ export function markNotificationsAsRead(
 ): Promise<AtlassianGraphQLResponse<MarkAsReadMutation>> {
   return performRequestForAccount(account, MarkAsReadDocument, {
     notificationIDs: notificationIds,
-    collabContextRoutingAri: cloudId
-      ? `ari:cloud:platform::site/${cloudId}`
-      : undefined,
+    collabContextRoutingAri: getCollabContextRoutingAri(cloudId),
   });
 }
 
@@ -152,9 +149,7 @@ export function markNotificationsAsUnread(
 ): Promise<AtlassianGraphQLResponse<MarkAsUnreadMutation>> {
   return performRequestForAccount(account, MarkAsUnreadDocument, {
     notificationIDs: notificationIds,
-    collabContextRoutingAri: cloudId
-      ? `ari:cloud:platform::site/${cloudId}`
-      : undefined,
+    collabContextRoutingAri: getCollabContextRoutingAri(cloudId),
   });
 }
 
@@ -164,6 +159,7 @@ export function markNotificationsAsUnread(
  * @param account - The account to fetch notifications for.
  * @param notificationGroupId - The ID of the notification group.
  * @param notificationGroupSize - The total number of notifications in the group (used to set page size).
+ * @param cloudId - When provided, scopes the request to that site via `collabContextRoutingAri`.
  * @returns Promise resolving to the GraphQL response containing notification group details.
  *
  * Endpoint documentation: https://developer.atlassian.com/platform/atlassian-graphql-api/graphql
@@ -172,6 +168,7 @@ export function getNotificationsByGroupId(
   account: Account,
   notificationGroupId: string,
   notificationGroupSize: number,
+  cloudId?: CloudID,
 ): Promise<AtlassianGraphQLResponse<RetrieveNotificationsByGroupIdQuery>> {
   const settings = useSettingsStore.getState();
   return performRequestForAccount(
@@ -183,6 +180,7 @@ export function getNotificationsByGroupId(
       readState: settings.fetchOnlyUnreadNotifications
         ? InfluentsNotificationReadState.Unread
         : null,
+      collabContextRoutingAri: getCollabContextRoutingAri(cloudId),
     },
   );
 }

--- a/src/renderer/utils/api/collabContextRouting.test.ts
+++ b/src/renderer/utils/api/collabContextRouting.test.ts
@@ -1,0 +1,17 @@
+import type { CloudID } from '../../types';
+
+import { getCollabContextRoutingAri } from './collabContextRouting';
+
+describe('renderer/utils/api/collabContextRouting.ts', () => {
+  it('returns undefined when no cloud ID is provided', () => {
+    expect(getCollabContextRoutingAri()).toBeUndefined();
+  });
+
+  it('returns the site-scoped routing ARI when a cloud ID is provided', () => {
+    const cloudId = 'mock-cloud-id' as CloudID;
+
+    expect(getCollabContextRoutingAri(cloudId)).toBe(
+      `ari:cloud:platform::site/${cloudId}`,
+    );
+  });
+});

--- a/src/renderer/utils/api/collabContextRouting.ts
+++ b/src/renderer/utils/api/collabContextRouting.ts
@@ -1,0 +1,13 @@
+import type { CloudID } from '../../types';
+
+/**
+ * Build the `collabContextRoutingAri` used to scope GraphQL requests to a specific Atlassian site.
+ *
+ * @param cloudId - The Atlassian tenant (site) cloud ID.
+ * @returns The site-scoped collaboration context routing ARI, or `undefined` when no cloud ID is provided.
+ */
+export function getCollabContextRoutingAri(
+  cloudId?: CloudID,
+): string | undefined {
+  return cloudId ? `ari:cloud:platform::site/${cloudId}` : undefined;
+}

--- a/src/renderer/utils/api/experimental/client.test.ts
+++ b/src/renderer/utils/api/experimental/client.test.ts
@@ -4,6 +4,7 @@ import { mockSingleAtlassifyNotification } from '../../../__mocks__/notification
 import type { CloudID, JiraProjectKey } from '../../../types';
 import type { AtlassianGraphQLResponse } from '../types';
 
+import { getCollabContextRoutingAri } from '../collabContextRouting';
 import * as request from '../request';
 import * as client from './client';
 
@@ -47,7 +48,7 @@ describe('renderer/utils/api/experimental/client.ts', () => {
       expect.stringContaining('mutation MarkGroupAsRead'),
       {
         groupId: mockSingleAtlassifyNotification.notificationGroup.id,
-        collabContextRoutingAri: `ari:cloud:platform::site/${mockCloudID}`,
+        collabContextRoutingAri: getCollabContextRoutingAri(mockCloudID),
       },
     );
   });
@@ -81,7 +82,7 @@ describe('renderer/utils/api/experimental/client.ts', () => {
       expect.stringContaining('mutation MarkGroupAsUnread'),
       {
         groupId: mockSingleAtlassifyNotification.notificationGroup.id,
-        collabContextRoutingAri: `ari:cloud:platform::site/${mockCloudID}`,
+        collabContextRoutingAri: getCollabContextRoutingAri(mockCloudID),
       },
     );
   });

--- a/src/renderer/utils/api/experimental/client.ts
+++ b/src/renderer/utils/api/experimental/client.ts
@@ -1,6 +1,7 @@
 import type { Account, CloudID, JiraProjectKey } from '../../../types';
 import type { AtlassianGraphQLResponse } from '../types';
 
+import { getCollabContextRoutingAri } from '../collabContextRouting';
 import {
   MarkGroupAsReadDocument,
   type MarkGroupAsReadMutation,
@@ -28,9 +29,7 @@ export function markNotificationGroupAsRead(
 ): Promise<AtlassianGraphQLResponse<MarkGroupAsReadMutation>> {
   return performRequestForAccount(account, MarkGroupAsReadDocument, {
     groupId: notificationGroupId,
-    collabContextRoutingAri: cloudId
-      ? `ari:cloud:platform::site/${cloudId}`
-      : undefined,
+    collabContextRoutingAri: getCollabContextRoutingAri(cloudId),
   });
 }
 
@@ -47,9 +46,7 @@ export function markNotificationGroupAsUnread(
 ): Promise<AtlassianGraphQLResponse<MarkGroupAsUnreadMutation>> {
   return performRequestForAccount(account, MarkGroupAsUnreadDocument, {
     groupId: notificationGroupId,
-    collabContextRoutingAri: cloudId
-      ? `ari:cloud:platform::site/${cloudId}`
-      : undefined,
+    collabContextRoutingAri: getCollabContextRoutingAri(cloudId),
   });
 }
 

--- a/src/renderer/utils/api/graphql/generated/graphql.ts
+++ b/src/renderer/utils/api/graphql/generated/graphql.ts
@@ -62,6 +62,7 @@ export type RetrieveNotificationsByGroupIdQueryVariables = Exact<{
   groupId: string;
   first?: number | null | undefined;
   readState?: InfluentsNotificationReadState | null | undefined;
+  collabContextRoutingAri?: string | null | undefined;
 }>;
 
 
@@ -269,12 +270,13 @@ export const MarkAsUnreadDocument = new TypedDocumentString(`
 }
     `) as unknown as TypedDocumentString<MarkAsUnreadMutation, MarkAsUnreadMutationVariables>;
 export const RetrieveNotificationsByGroupIdDocument = new TypedDocumentString(`
-    query RetrieveNotificationsByGroupId($groupId: String!, $first: Int, $readState: InfluentsNotificationReadState) {
+    query RetrieveNotificationsByGroupId($groupId: String!, $first: Int, $readState: InfluentsNotificationReadState, $collabContextRoutingAri: String) {
   notifications {
     notificationGroup(
       groupId: $groupId
       first: $first
       filter: { readStateFilter: $readState }
+      collabContextRoutingAri: $collabContextRoutingAri
     ) {
       nodes {
         ...GroupNotificationDetails

--- a/src/renderer/utils/notifications/group.test.ts
+++ b/src/renderer/utils/notifications/group.test.ts
@@ -6,8 +6,11 @@ import {
 
 import { useSettingsStore } from '../../stores';
 
-import type { AtlassifyNotification } from '../../types';
+import type { AtlassifyNotification, CloudID } from '../../types';
+import type { AtlassianGraphQLResponse } from '../api/types';
 
+import * as client from '../api/client';
+import type { RetrieveNotificationsByGroupIdQuery } from '../api/graphql/generated/graphql';
 import {
   getFlattenedNotificationsByProduct,
   getNotificationIdsForGroups,
@@ -266,6 +269,46 @@ describe('renderer/utils/notifications/group.ts', () => {
       );
 
       expect(result).toEqual([]);
+    });
+
+    it('should scope group lookup to the provided cloud ID', async () => {
+      const cloudId = 'mock-cloud-id' as unknown as CloudID;
+      const groupNotification: AtlassifyNotification = {
+        ...mockSingleAtlassifyNotification,
+        notificationGroup: {
+          ...mockSingleAtlassifyNotification.notificationGroup,
+          size: 3,
+        },
+      };
+
+      const getNotificationsByGroupIdSpy = vi
+        .spyOn(client, 'getNotificationsByGroupId')
+        .mockResolvedValue({
+          data: {
+            notifications: {
+              notificationGroup: {
+                nodes: [
+                  { notificationId: 'member-1', readState: 'unread' },
+                  { notificationId: 'member-2', readState: 'unread' },
+                ],
+              },
+            },
+          },
+        } as unknown as AtlassianGraphQLResponse<RetrieveNotificationsByGroupIdQuery>);
+
+      const result = await getNotificationIdsForGroups(
+        mockAtlassianCloudAccount,
+        [groupNotification],
+        cloudId,
+      );
+
+      expect(getNotificationsByGroupIdSpy).toHaveBeenCalledWith(
+        mockAtlassianCloudAccount,
+        groupNotification.notificationGroup.id,
+        groupNotification.notificationGroup.size,
+        cloudId,
+      );
+      expect(result).toEqual(['member-1', 'member-2']);
     });
   });
 });

--- a/src/renderer/utils/notifications/group.ts
+++ b/src/renderer/utils/notifications/group.ts
@@ -1,6 +1,6 @@
 import { useSettingsStore } from '../../stores';
 
-import type { Account, AtlassifyNotification } from '../../types';
+import type { Account, AtlassifyNotification, CloudID } from '../../types';
 
 import { getNotificationsByGroupId } from '../api/client';
 import type { GroupNotificationDetailsFragment } from '../api/graphql/generated/graphql';
@@ -114,11 +114,13 @@ export function getFlattenedNotificationsByProduct(
  *
  * @param account The account to use for fetching group notifications
  * @param notifications List of notifications (may include group notifications)
+ * @param cloudId When provided, scopes the group lookup to that site via `collabContextRoutingAri`
  * @returns Promise resolving to a flat array of notification IDs
  */
 export async function resolveNotificationIdsForGroup(
   account: Account,
   notifications: AtlassifyNotification[],
+  cloudId?: CloudID,
 ): Promise<string[]> {
   // Separate single and group notifications
 
@@ -128,6 +130,7 @@ export async function resolveNotificationIdsForGroup(
   const groupedNotificationIds = await getNotificationIdsForGroups(
     account,
     notifications,
+    cloudId,
   );
 
   return [...singleNotificationIDs, ...groupedNotificationIds];
@@ -154,11 +157,13 @@ export function getNotificationIdsForNonGroups(
  *
  * @param account - The account to use for fetching group notifications.
  * @param notifications - List of notifications (may include group notifications).
+ * @param cloudId - When provided, scopes the group lookup to that site via `collabContextRoutingAri`.
  * @returns Promise resolving to a flat array of notification IDs for all group notifications.
  */
 export async function getNotificationIdsForGroups(
   account: Account,
   notifications: AtlassifyNotification[],
+  cloudId?: CloudID,
 ): Promise<string[]> {
   const notificationIDs: string[] = [];
 
@@ -172,6 +177,7 @@ export async function getNotificationIdsForGroups(
         account,
         group.notificationGroup.id,
         group.notificationGroup.size,
+        cloudId,
       );
 
       const nodes = res.data.notifications.notificationGroup


### PR DESCRIPTION
Fixes #3207

continuation of context routing fix.

as reported, marking a notification as read/unread was not working - https://github.com/setchy/atlassify/issues/3207#issuecomment-5256024721

after further debugging, this was due to a missing path with grouped notification interactions

